### PR TITLE
Add ARM NEON acceleration

### DIFF
--- a/src/qtractorInsertPlugin.cpp
+++ b/src/qtractorInsertPlugin.cpp
@@ -155,6 +155,94 @@ static inline void sse_process_add (
 
 #endif
 
+#if defined(__ARM_NEON__)
+#include "arm_neon.h"
+
+// NEON enabled processor versions.
+static inline void neon_process_gain (
+	float **ppFrames, unsigned int iFrames,
+	unsigned short iChannels, float fGain )
+{
+	float32x4_t vGain = vdupq_n_f32(fGain);
+
+	for (unsigned short i = 0; i < iChannels; ++i) {
+		float *pFrames = ppFrames[i];
+		unsigned int nframes = iFrames;
+		for (; (long(pFrames) & 15) && (nframes > 0); --nframes)
+			*pFrames++ *= fGain;
+		for (; nframes >= 4; nframes -= 4) {
+			vst1q_f32(pFrames,
+				vmulq_f32(
+					vld1q_f32(pFrames), vGain
+				)
+			);
+			pFrames += 4;
+		}
+		for (; nframes > 0; --nframes)
+			*pFrames++ *= fGain;
+	}
+}
+
+static inline void neon_process_dry_wet (
+	float **ppBuffer, float **ppFrames, unsigned int iFrames,
+	unsigned short iChannels, float fDry, float fWet )
+{
+	float32x4_t vDry = vdupq_n_f32(fDry);
+	float32x4_t vWet = vdupq_n_f32(fWet);
+
+	for (unsigned short i = 0; i < iChannels; ++i) {
+		float *pBuffer = ppBuffer[i];
+		float *pFrames = ppFrames[i];
+		unsigned int nframes = iFrames;
+		for (; (long(pBuffer) & 15) && (nframes > 0); --nframes) {
+			*pBuffer   *= fWet;
+			*pBuffer++ += fDry * *pFrames++;
+		}
+		for (; nframes >= 4; nframes -= 4) {
+			float32x4_t vBuffer = vld1q_f32(pBuffer);
+			vBuffer = vmulq_f32(vBuffer, vWet);
+			float32x4_t vFrames = vld1q_f32(pFrames);
+			// Vr[i] := Va[i] + Vb[i] * Vc[i]
+			vBuffer = vmlaq_f32(vBuffer, vDry, vFrames);
+			vst1q_f32(pBuffer, vBuffer);
+			pFrames += 4;
+			pBuffer += 4;
+		}
+		for (; nframes > 0; --nframes) {
+			*pBuffer   *= fWet;
+			*pBuffer++ += fDry * *pFrames++;
+		}
+	}
+}
+
+static inline void neon_process_add (
+	float **ppBuffer, float **ppFrames, unsigned int iFrames,
+	unsigned short iChannels, float fGain )
+{
+	float32x4_t vGain = vdupq_n_f32(fGain);
+
+	for (unsigned short i = 0; i < iChannels; ++i) {
+		float *pBuffer = ppBuffer[i];
+		float *pFrames = ppFrames[i];
+		unsigned int nframes = iFrames;
+		for (; (long(pBuffer) & 15) && (nframes > 0); --nframes)
+			*pBuffer++ += fGain * *pFrames++;
+		for (; nframes >= 4; nframes -= 4) {
+			float32x4_t vBuffer = vld1q_f32(pBuffer);
+			float32x4_t vFrames = vld1q_f32(pFrames);
+			//Vr[i] := Va[i] + Vb[i] * Vc[i]
+			vBuffer = vmlaq_f32(vBuffer, vGain, vFrames);
+			vst1q_f32(pBuffer, vBuffer);
+			pFrames += 4;
+			pBuffer += 4;
+		}
+		for (; nframes > 0; --nframes)
+			*pBuffer++ += fGain * *pFrames++;
+	}
+}
+
+#endif
+
 
 // Standard processor versions.
 static inline void std_process_gain (
@@ -367,13 +455,17 @@ qtractorAudioInsertPlugin::qtractorAudioInsertPlugin (
 	if (sse_enabled()) {
 		m_pfnProcessGain = sse_process_gain;
 		m_pfnProcessDryWet = sse_process_dry_wet;
-	} else {
+	} else
 #endif
-	m_pfnProcessGain = std_process_gain;
-	m_pfnProcessDryWet = std_process_dry_wet;
-#if defined(__SSE__)
+#if defined(__ARM_NEON__)
+	m_pfnProcessGain = neon_process_gain;
+	m_pfnProcessDryWet = neon_process_dry_wet;
+	if(false)
+#endif
+	{
+		m_pfnProcessGain = std_process_gain;
+		m_pfnProcessDryWet = std_process_dry_wet;
 	}
-#endif
 
 	// Create and attach the custom parameters...
 	m_pSendGainParam = new qtractorInsertPluginParam(this, 0);
@@ -1120,12 +1212,15 @@ qtractorAudioAuxSendPlugin::qtractorAudioAuxSendPlugin (
 #if defined(__SSE__)
 	if (sse_enabled()) {
 		m_pfnProcessAdd = sse_process_add;
-	} else {
+	} else
 #endif
+#if defined(__ARM_NEON__)
+	m_pfnProcessAdd = neon_process_add;
+	if(false)
+#endif
+    {
 		m_pfnProcessAdd = std_process_add;
-#if defined(__SSE__)
 	}
-#endif
 
 	// Create and attach the custom parameters...
 	m_pSendGainParam = new qtractorInsertPluginParam(this, 0);


### PR DESCRIPTION
* More or less a 1/1 copy of SSE implementation. Where possible make use of
  multiply/accumulate (vmla)
* Runtime NEON detection is not easy to implement. The only implementations I
  found did not work properly e.g [1]. So let's trust the compiler.
* On RaspberryPi3 test arrangement with 8 Midi-Tracks / 4 LV2-Plugins the idle
  load is reduced from 30% -> 29%.

[1] http://git.openembedded.org/meta-openembedded/commit/meta-oe?id=cae9cafb9c536fd5ea40d1457c0ee1fcd6a6aa43

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>