### PR TITLE
workaround native file dialogs hang up by setting parent to NULL

### DIFF
--- a/src/qtractorAudioListView.cpp
+++ b/src/qtractorAudioListView.cpp
@@ -146,11 +146,11 @@ QStringList qtractorAudioListView::getOpenFileNames (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	files = QFileDialog::getOpenFileNames(this,
+	files = QFileDialog::getOpenFileNames(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, recentDir(), qtractorAudioFileFactory::filters(), NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, recentDir(), qtractorAudioFileFactory::filters());
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);

--- a/src/qtractorClipForm.cpp
+++ b/src/qtractorClipForm.cpp
@@ -703,10 +703,10 @@ void qtractorClipForm::browseFilename (void)
 	if (pOptions && pOptions->bDontUseNativeDialogs)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
-	sFilename = QFileDialog::getOpenFileName(this,
+	sFilename = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.FilenameComboBox->currentText(), sFilter, NULL, options);
 #else
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.FilenameComboBox->currentText(), sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);

--- a/src/qtractorExportForm.cpp
+++ b/src/qtractorExportForm.cpp
@@ -407,10 +407,10 @@ void qtractorExportForm::browseExportPath (void)
 	if (pOptions && pOptions->bDontUseNativeDialogs)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
-	sExportPath = QFileDialog::getSaveFileName(this,
+	sExportPath = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sExportPath, sFilter, NULL, options);
 #else
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sExportPath, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptSave);

--- a/src/qtractorInstrumentForm.cpp
+++ b/src/qtractorInstrumentForm.cpp
@@ -228,11 +228,11 @@ void qtractorInstrumentForm::importSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	files = QFileDialog::getOpenFileNames(this,
+	files = QFileDialog::getOpenFileNames(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sInstrumentDir, sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sInstrumentDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -388,11 +388,11 @@ void qtractorInstrumentForm::exportSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	sPath = QFileDialog::getSaveFileName(this,
+	sPath = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sInstrumentDir, sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sInstrumentDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptSave);

--- a/src/qtractorMainForm.cpp
+++ b/src/qtractorMainForm.cpp
@@ -1950,11 +1950,11 @@ bool qtractorMainForm::openSession (void)
 	if (m_pOptions->bDontUseNativeDialogs)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
-	sFilename = QFileDialog::getOpenFileName(this,
+	sFilename = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_pOptions->sSessionDir, sFilter, NULL, options);
 #else
 	// Construct open-file session/template dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_pOptions->sSessionDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -2043,11 +2043,11 @@ bool qtractorMainForm::saveSession ( bool bPrompt )
 		// Try to rename as if a backup is about...
 		sFilename = sessionBackupPath(sFilename);
 	#if 1//QT_VERSION < 0x040400
-		sFilename = QFileDialog::getSaveFileName(this,
+		sFilename = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 			sTitle, sFilename, sFilter, NULL, options);
 	#else
 		// Construct save-file session/template dialog...
-		QFileDialog fileDialog(this,
+		QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 			sTitle, sFilename, sFilter);
 		// Set proper save-file modes...
 		fileDialog.setAcceptMode(QFileDialog::AcceptSave);

--- a/src/qtractorMidiControlForm.cpp
+++ b/src/qtractorMidiControlForm.cpp
@@ -237,11 +237,11 @@ void qtractorMidiControlForm::importSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	files = QFileDialog::getOpenFileNames(this,
+	files = QFileDialog::getOpenFileNames(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiControlDir, sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiControlDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -450,11 +450,11 @@ void qtractorMidiControlForm::exportSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	sPath = QFileDialog::getSaveFileName(this,
+	sPath = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sPath, sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this, sTitle, sPath, sFilter);
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle, sPath, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptSave);
 	fileDialog.setFileMode(QFileDialog::AnyFile);

--- a/src/qtractorMidiEditorForm.cpp
+++ b/src/qtractorMidiEditorForm.cpp
@@ -1043,11 +1043,11 @@ bool qtractorMidiEditorForm::saveClipFile ( bool bPrompt )
 			options |= QFileDialog::DontUseNativeDialog;
 	#if 1//QT_VERSION < 0x040400
 		// Ask for the filenames to open...
-		sFilename = QFileDialog::getSaveFileName(this,
+		sFilename = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 			sTitle, sFilename, sFilter, NULL, options);
 	#else
 		// Construct open-files dialog...
-		QFileDialog fileDialog(this,
+		QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 			sTitle, sFilename, sFilter);
 		// Set proper open-file modes...
 		fileDialog.setAcceptMode(QFileDialog::AcceptSave);

--- a/src/qtractorMidiListView.cpp
+++ b/src/qtractorMidiListView.cpp
@@ -188,11 +188,11 @@ QStringList qtractorMidiListView::getOpenFileNames (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filenames to open...
-	files = QFileDialog::getOpenFileNames(this,
+	files = QFileDialog::getOpenFileNames(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, recentDir(), sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, recentDir(), sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);

--- a/src/qtractorMidiSysexForm.cpp
+++ b/src/qtractorMidiSysexForm.cpp
@@ -224,11 +224,11 @@ void qtractorMidiSysexForm::importSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	files = QFileDialog::getOpenFileNames(this,
+	files = QFileDialog::getOpenFileNames(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiSysexDir, sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiSysexDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -302,11 +302,11 @@ void qtractorMidiSysexForm::exportSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1// QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	sPath = QFileDialog::getSaveFileName(this,
+	sPath = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiSysexDir, sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiSysexDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptSave);
@@ -443,11 +443,11 @@ void qtractorMidiSysexForm::openSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to save...
-	sFilename = QFileDialog::getOpenFileName(this,
+	sFilename = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiSysexDir, sFilter, NULL, options);
 #else
 	// Construct save-file dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sMidiSysexDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -515,11 +515,11 @@ void qtractorMidiSysexForm::saveSlot (void)
 			options |= QFileDialog::DontUseNativeDialog;
 	#if 1//QT_VERSION < 0x040400
 		// Ask for the filename to save...
-		sFilename = QFileDialog::getSaveFileName(this,
+		sFilename = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 			sTitle, sFilename, sFilter, NULL, options);
 	#else
 		// Construct save-file dialog...
-		QFileDialog fileDialog(this, sTitle, sFilename, sFilter);
+		QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle, sFilename, sFilter);
 		// Set proper open-file modes...
 		fileDialog.setAcceptMode(QFileDialog::AcceptSave);
 		fileDialog.setFileMode(QFileDialog::AnyFile);

--- a/src/qtractorOptionsForm.cpp
+++ b/src/qtractorOptionsForm.cpp
@@ -1170,11 +1170,11 @@ void qtractorOptionsForm::choosePluginPath (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the directory...
-	sPluginPath = QFileDialog::getExistingDirectory(this,
+	sPluginPath = QFileDialog::getExistingDirectory(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.PluginPathComboBox->currentText(), options);
 #else
 	// Construct open-directory dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.PluginPathComboBox->currentText());
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -1407,11 +1407,11 @@ void qtractorOptionsForm::chooseLv2PresetDir (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1// QT_VERSION < 0x040400
 	// Ask for the directory...
-	sLv2PresetDir = QFileDialog::getExistingDirectory(this,
+	sLv2PresetDir = QFileDialog::getExistingDirectory(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sLv2PresetDir, options);
 #else
 	// Construct open-directory dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sLv2PresetDir);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -1473,11 +1473,11 @@ void qtractorOptionsForm::chooseMessagesLogPath (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	sFilename = QFileDialog::getSaveFileName(this,
+	sFilename = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.MessagesLogPathComboBox->currentText(), sFilter, NULL, options);
 #else
 	// Construct open-file dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.MessagesLogPathComboBox->currentText(), sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptSave);
@@ -1513,11 +1513,11 @@ void qtractorOptionsForm::chooseSessionTemplatePath (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	sFilename = QFileDialog::getOpenFileName(this,
+	sFilename = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.SessionTemplatePathComboBox->currentText(), sFilter, NULL, options);
 #else
 	// Construct open-files dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.SessionTemplatePathComboBox->currentText(), sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -1668,11 +1668,11 @@ QString qtractorOptionsForm::getOpenAudioFileName (
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	sAudioFile = QFileDialog::getOpenFileName(this,
+	sAudioFile = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sFilename, qtractorAudioFileFactory::filters(), NULL, options);
 #else
 	// Construct open-file dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sFilename, qtractorAudioFileFactory::filters());
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);

--- a/src/qtractorPluginForm.cpp
+++ b/src/qtractorPluginForm.cpp
@@ -562,11 +562,11 @@ void qtractorPluginForm::openPresetSlot (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to save...
-	sFilename = QFileDialog::getOpenFileName(this,
+	sFilename = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sPresetDir, sFilter, NULL, options);
 #else
 	// Construct save-file dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, pOptions->sPresetDir, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -654,11 +654,11 @@ void qtractorPluginForm::savePresetSlot (void)
 				options |= QFileDialog::DontUseNativeDialog;
 		#if 1//QT_VERSION < 0x040400
 			// Ask for the filename to save...
-			sFilename = QFileDialog::getSaveFileName(this,
+			sFilename = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 				sTitle, sFilename, sFilter, NULL, options);
 		#else
 			// Construct save-file dialog...
-			QFileDialog fileDialog(this,
+			QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 				sTitle, sFilename, sFilter);
 			// Set proper open-file modes...
 			fileDialog.setAcceptMode(QFileDialog::AcceptSave);
@@ -1515,11 +1515,11 @@ void qtractorPluginPropertyWidget::buttonClicked (void)
 	if (pOptions->bDontUseNativeDialogs)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
-	sFilename = QFileDialog::getOpenFileName(this,
+	sFilename = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sFilename, QString(), NULL, options);
 #else
 	// Construct open-file dialog...
-	QFileDialog fileDialog(this, sTitle, sFilename);
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle, sFilename);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
 	fileDialog.setFileMode(QFileDialog::ExistingFile);

--- a/src/qtractorSessionForm.cpp
+++ b/src/qtractorSessionForm.cpp
@@ -292,11 +292,11 @@ void qtractorSessionForm::browseSessionDir (void)
 	if (pOptions->bDontUseNativeDialogs)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
-	QString sSessionDir = QFileDialog::getExistingDirectory(this,                                  // Parent.
+	QString sSessionDir = QFileDialog::getExistingDirectory(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.SessionDirComboBox->currentText(), options);
 #else
 	// Construct open-directory dialog...
-	QFileDialog fileDialog(this,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, m_ui.SessionDirComboBox->currentText());
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);

--- a/src/qtractorTrackForm.cpp
+++ b/src/qtractorTrackForm.cpp
@@ -1168,11 +1168,11 @@ void qtractorTrackForm::trackIconClicked (void)
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to open...
-	sFilename = QFileDialog::getOpenFileName(this,
+	sFilename = QFileDialog::getOpenFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL,
 		sTitle, sFilename, sFilter, NULL, options);
 #else
 	// Construct open-file dialog...
-	QFileDialog fileDialog(this, sTitle, sFilename, sFilter);
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle, sFilename, sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
 	fileDialog.setFileMode(QFileDialog::AnyFile);

--- a/src/qtractorTracks.cpp
+++ b/src/qtractorTracks.cpp
@@ -1190,11 +1190,11 @@ bool qtractorTracks::mergeExportAudioClips ( qtractorClipCommand *pClipCommand )
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to save...
-	QString sFilename = QFileDialog::getSaveFileName(this, sTitle,
+	QString sFilename = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle,
 		pSession->createFilePath(pTrack->trackName(), sExt), sFilter, NULL, options);
 #else
 	// Construct save-file dialog...
-	QFileDialog fileDialog(this, sTitle,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle,
 		pSession->createFilePath(pTrack->trackName(), sExt), sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptSave);
@@ -1457,11 +1457,11 @@ bool qtractorTracks::mergeExportMidiClips ( qtractorClipCommand *pClipCommand )
 		options |= QFileDialog::DontUseNativeDialog;
 #if 1//QT_VERSION < 0x040400
 	// Ask for the filename to save...
-	QString sFilename = QFileDialog::getSaveFileName(this, sTitle,
+	QString sFilename = QFileDialog::getSaveFileName(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle,
 		pSession->createFilePath(pTrack->trackName(), sExt), sFilter, NULL, options);
 #else
 	// Construct save-file dialog...
-	QFileDialog fileDialog(this, sTitle,
+	QFileDialog fileDialog(options & QFileDialog::DontUseNativeDialog ? this : NULL, sTitle,
 		pSession->createFilePath(pTrack->trackName(), sExt), sFilter);
 	// Set proper open-file modes...
 	fileDialog.setAcceptMode(QFileDialog::AcceptSave);

--- a/src/qtractorVstPlugin.cpp
+++ b/src/qtractorVstPlugin.cpp
@@ -1507,10 +1507,10 @@ static VstIntPtr qtractorVstPlugin_openFileSelector (
 		const QFileDialog::Options options = QFileDialog::DontUseNativeDialog;
 		if (pvfs->command == kVstFileLoad) {
 			sFilename = QFileDialog::getOpenFileName(
-				pParentWidget, sTitle, sDirectory, sFilter, NULL, options);
+				NULL, sTitle, sDirectory, sFilter, NULL, options);
 		} else {
 			sFilename = QFileDialog::getSaveFileName(
-				pParentWidget, sTitle, sDirectory, sFilter, NULL, options);
+				options & QFileDialog::DontUseNativeDialog ? pParentWidget, sTitle, sDirectory, sFilter, NULL, options);
 		}
 		if (!sFilename.isEmpty()) {
 			if (pvfs->returnPath == NULL) {
@@ -1530,7 +1530,7 @@ static VstIntPtr qtractorVstPlugin_openFileSelector (
 			= QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog;
 		const QString& sDirectory
 			= QFileDialog::getExistingDirectory(
-				pParentWidget, sTitle, pvfs->initialPath, options);
+				options & QFileDialog::DontUseNativeDialog ? pParentWidget, sTitle, pvfs->initialPath, options);
 		if (!sDirectory.isEmpty()) {
 			if (pvfs->returnPath == NULL) {
 				pvfs->returnPath = new char [sDirectory.length() + 1];


### PR DESCRIPTION
Honestly not all locations were tested but for fedora 25 and Raspberrry PI
it fixed:

* Save session choose path
* Save session choose file
* Open session choose file

It should be noted that dialogs now get an own entry in the taskbar.

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>