### PR TITLE
Boost qtractor's performance by deactivating quiet plugins

### DIFF
--- a/src/qtractorMainForm.cpp
+++ b/src/qtractorMainForm.cpp
@@ -876,6 +876,9 @@ qtractorMainForm::qtractorMainForm (
 	QObject::connect(m_ui.trackAutoMonitorAction,
 		SIGNAL(triggered(bool)),
 		SLOT(trackAutoMonitor(bool)));
+	QObject::connect(m_ui.trackAutoDeactivatePluginsAction,
+		SIGNAL(triggered(bool)),
+		SLOT(trackAutoDeactivatePlugins(bool)));
 	QObject::connect(m_ui.trackImportAudioAction,
 		SIGNAL(triggered(bool)),
 		SLOT(trackImportAudio()));
@@ -1373,6 +1376,9 @@ void qtractorMainForm::setup ( qtractorOptions *pOptions )
 	m_pSession->setAutoTimeStretch(m_pOptions->bAudioAutoTimeStretch);
 	m_pSession->setLoopRecordingMode(m_pOptions->iLoopRecordingMode);
 
+	// Initial auto plugin deactivation
+	m_pSession->setAutoDeactivatePlugins(m_pOptions->bAutoDeactivatePlugins);
+
 	// Initial decorations toggle state.
 	m_ui.viewMenubarAction->setChecked(m_pOptions->bMenubar);
 	m_ui.viewStatusbarAction->setChecked(m_pOptions->bStatusbar);
@@ -1394,6 +1400,7 @@ void qtractorMainForm::setup ( qtractorOptions *pOptions )
 	m_ui.transportContinueAction->setChecked(m_pOptions->bContinuePastEnd);
 
 	m_ui.trackAutoMonitorAction->setChecked(m_pOptions->bAutoMonitor);
+	m_ui.trackAutoDeactivatePluginsAction->setChecked(m_pOptions->bAutoDeactivatePlugins);
 
 	// Initial decorations visibility state.
 	viewMenubar(m_pOptions->bMenubar);
@@ -1688,6 +1695,7 @@ bool qtractorMainForm::queryClose (void)
 			m_pOptions->bAutoBackward = m_ui.transportAutoBackwardAction->isChecked();
 			m_pOptions->bContinuePastEnd = m_ui.transportContinueAction->isChecked();
 			m_pOptions->bAutoMonitor = m_ui.trackAutoMonitorAction->isChecked();
+			m_pOptions->bAutoDeactivatePlugins = m_ui.trackAutoDeactivatePluginsAction->isChecked();
 			// Final zoom mode...
 			if (m_pTracks)
 				m_pOptions->iZoomMode = m_pTracks->zoomMode();
@@ -3729,6 +3737,17 @@ void qtractorMainForm::trackAutoMonitor ( bool bOn )
 	if (bOn && m_pTracks)
 		pTrack = m_pTracks->currentTrack();
 	m_pSession->setCurrentTrack(pTrack);
+}
+
+
+// Auto-deactivate plugins not producing sound.
+void qtractorMainForm::trackAutoDeactivatePlugins ( bool bOn )
+{
+#ifdef CONFIG_DEBUG
+	qDebug("qtractorMainForm::trackAutoDeactivatePlugins(%d)", int(bOn));
+#endif
+
+	m_pSession->setAutoDeactivatePlugins(bOn);
 }
 
 

--- a/src/qtractorMainForm.h
+++ b/src/qtractorMainForm.h
@@ -178,6 +178,7 @@ public slots:
 	void trackHeightDown();
 	void trackHeightReset();
 	void trackAutoMonitor(bool bOn);
+	void trackAutoDeactivatePlugins(bool bOn);
 	void trackImportAudio();
 	void trackImportMidi();
 	void trackExportAudio();

--- a/src/qtractorMainForm.ui
+++ b/src/qtractorMainForm.ui
@@ -318,6 +318,7 @@
     <addaction name="trackHeightMenu"/>
     <addaction name="separator"/>
     <addaction name="trackAutoMonitorAction"/>
+    <addaction name="trackAutoDeactivatePluginsAction"/>
     <addaction name="separator"/>
     <addaction name="trackImportMenu"/>
     <addaction name="trackExportMenu"/>
@@ -1439,6 +1440,26 @@
    </property>
    <property name="shortcut">
     <string>F6</string>
+   </property>
+  </action>
+  <action name="trackAutoDeactivatePluginsAction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Auto Deactivate</string>
+   </property>
+   <property name="iconText">
+    <string>Auto Deactivate</string>
+   </property>
+   <property name="toolTip">
+    <string>Auto-deactivate plugins</string>
+   </property>
+   <property name="statusTip">
+    <string>Auto-deactivate plugins not producing sound</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+F6</string>
    </property>
   </action>
   <action name="trackImportAudioAction">

--- a/src/qtractorOptions.cpp
+++ b/src/qtractorOptions.cpp
@@ -198,6 +198,7 @@ void qtractorOptions::loadOptions (void)
 	sMidiControlDir = m_settings.value("/MidiControlDir").toString();
 	sMidiSysexDir   = m_settings.value("/MidiSysexDir").toString();
 	bAutoMonitor    = m_settings.value("/AutoMonitor", true).toBool();
+	bAutoDeactivatePlugins = m_settings.value("/AutoDeactivatePlugins", false).toBool();
 	iSnapPerBeat    = m_settings.value("/SnapPerBeat", 4).toInt();
 	fTempo    = float(m_settings.value("/Tempo", 120.0).toDouble());
 	iBeatsPerBar    = m_settings.value("/BeatsPerBar", 4).toInt();
@@ -489,6 +490,7 @@ void qtractorOptions::saveOptions (void)
 	m_settings.setValue("/MidiControlDir", sMidiControlDir);
 	m_settings.setValue("/MidiSysexDir", sMidiSysexDir);
 	m_settings.setValue("/AutoMonitor", bAutoMonitor);
+	m_settings.setValue("/AutoDeactivatePlugins", bAutoDeactivatePlugins);
 	m_settings.setValue("/SnapPerBeat", iSnapPerBeat);
 	m_settings.setValue("/Tempo", double(fTempo));
 	m_settings.setValue("/BeatsPerBar", iBeatsPerBar);

--- a/src/qtractorOptions.h
+++ b/src/qtractorOptions.h
@@ -169,6 +169,7 @@ public:
 	bool    bSessionBackup;
 	int     iSessionBackupMode;
 	bool	bAutoMonitor;
+	bool	bAutoDeactivatePlugins;
 	int     iSnapPerBeat;
 	float   fTempo;
 	int     iBeatsPerBar;

--- a/src/qtractorPlugin.h
+++ b/src/qtractorPlugin.h
@@ -364,7 +364,7 @@ public:
 	// Activation methods.
 	void setActivated(bool bActivated);
 	void setActivatedEx(bool bActivated);
-	bool isActivated() const;
+	bool isActivated(bool bSaveSession = false) const;
 
 	// Activate subject accessors.
 	qtractorSubject *activateSubject()
@@ -645,6 +645,8 @@ public:
 	// Parameter update executive.
 	void updateParamValue(unsigned long iIndex, float fValue, bool bUpdate);
 
+	// Performance activation
+	void deactivateForPerformance(bool bDeactivated);
 protected:
 
 	// Instance number settler.
@@ -668,6 +670,12 @@ private:
 
 	// Activation flag.
 	bool m_bActivated;
+
+	// Performance deactivation flag
+	bool m_bDeactivatedForPerformance;
+
+	// Detect first activation
+	bool m_bInitActivationDone;
 
 	// Activate subject value.
 	qtractorSubject m_activateSubject;
@@ -914,6 +922,10 @@ public:
 	bool isAudioInsertActivated() const
 		{ return (m_iAudioInsertActivated > 0); }
 
+	// Special performance deactivate methods
+	void deactivateForPerformance(bool bDeactivated);
+	bool isDeactivatedForPerformance();
+
 protected:
 
 	// Check/sanitize plugin file-path.
@@ -961,6 +973,9 @@ private:
 
 	// Plugin registry (chain unique ids.)
 	QHash<unsigned long, unsigned int> m_uniqueIDs;
+
+	// Performance deactivation
+	bool m_bDeactivateForPerformance;
 };
 
 

--- a/src/qtractorPluginListView.cpp
+++ b/src/qtractorPluginListView.cpp
@@ -1631,25 +1631,26 @@ void qtractorPluginListView::contextMenuEvent (
 	pAction->setEnabled(bMidiInsertPlugin);
 	menu.addSeparator();
 
+	const bool bDeactivatedForPerformance = m_pPluginList->isDeactivatedForPerformance();
 	pAction = menu.addAction(
 		tr("Ac&tivate"), this, SLOT(activatePlugin()));
 	pAction->setCheckable(true);
 	pAction->setChecked(pPlugin && pPlugin->isActivated());
-	pAction->setEnabled(pPlugin != NULL);
+	pAction->setEnabled(pPlugin && !bDeactivatedForPerformance);
 
 	const bool bActivatedAll = m_pPluginList->isActivatedAll();
 	pAction = menu.addAction(
 		tr("Acti&vate All"), this, SLOT(activateAllPlugins()));
 	pAction->setCheckable(true);
 	pAction->setChecked(bActivatedAll);
-	pAction->setEnabled(bEnabled && !bActivatedAll);
+	pAction->setEnabled(bEnabled && !bActivatedAll && !bDeactivatedForPerformance);
 
 	const bool bDeactivatedAll = !m_pPluginList->isActivated();
 	pAction = menu.addAction(
 		tr("Deactivate Al&l"), this, SLOT(deactivateAllPlugins()));
 	pAction->setCheckable(true);
 	pAction->setChecked(bDeactivatedAll);
-	pAction->setEnabled(bEnabled && !bDeactivatedAll);
+	pAction->setEnabled(bEnabled && !bDeactivatedAll && !bDeactivatedForPerformance);
 
 	menu.addSeparator();
 

--- a/src/qtractorSession.cpp
+++ b/src/qtractorSession.cpp
@@ -119,6 +119,8 @@ qtractorSession::qtractorSession (void)
 
 	m_bAutoTimeStretch  = false;
 
+	m_bDeactivatePluginsForPerformance = false;
+
 	m_iLoopRecordingMode = 0;
 
 	clear();
@@ -1757,31 +1759,53 @@ void qtractorSession::trackSolo ( qtractorTrack *pTrack, bool bSolo )
 	}
 }
 
+// Auto plugin deactivation specifics
 void qtractorSession::deactivatePluginsForPerformance()
 {
-	// For session load deactivation of plugins would be too early
-	if(!isBusy()) {
+	// Enabled && not if busy (e.g loading session)
+	if(m_bDeactivatePluginsForPerformance && !isBusy()) {
 		for (qtractorTrack *pTrack = m_tracks.first();
 				pTrack; pTrack = pTrack->next()) {
-			// Pluginlist knows what to do...
 			pTrack->pluginList()->deactivateForPerformance(!canTrackMakeSound(pTrack));
 		}
 	}
 }
 
+void qtractorSession::undoDeactivatePluginsForPerformance()
+{
+	for (qtractorTrack *pTrack = m_tracks.first();
+			pTrack; pTrack = pTrack->next()) {
+		pTrack->pluginList()->deactivateForPerformance(false);
+	}
+}
+
+void qtractorSession::setAutoDeactivatePlugins( bool bOn )
+{
+	m_bDeactivatePluginsForPerformance = bOn;
+
+	if(bOn)
+		deactivatePluginsForPerformance();
+	else
+		undoDeactivatePluginsForPerformance();
+}
+
 bool qtractorSession::canTrackMakeSound(qtractorTrack *pTrack)
 {
-	bool bProduceSound = false;
-	if(isPlaying())	{
-		// TBD: We know when clips start/end. So if 'just' need a
-		// clever song pos synced call of deactivatePluginsForPerformance
-		bProduceSound = isTrackMonitor(pTrack) || !pTrack->isMute();
-	}
-	else {
-		bProduceSound = isTrackMonitor(pTrack);
+	bool bProduceSound = true;
+	// No deactivation for freewheeling
+	if(!m_pAudioEngine->isFreewheel()) {
+		if(isPlaying())	{
+			// TBD: We know when clips start/end. So if 'just' need a
+			// clever song pos synced call of deactivatePluginsForPerformance
+			bProduceSound = isTrackMonitor(pTrack) || !pTrack->isMute();
+		}
+		else {
+			bProduceSound = isTrackMonitor(pTrack);
+		}
 	}
 	return bProduceSound;
 }
+
 
 // Track recording specifics.
 unsigned short qtractorSession::audioRecord (void) const

--- a/src/qtractorSession.h
+++ b/src/qtractorSession.h
@@ -318,6 +318,9 @@ public:
 	void trackMute(qtractorTrack *pTrack, bool bMute);
 	void trackSolo(qtractorTrack *pTrack, bool bSolo);
 
+	// Special performance optimized plugin activation
+	void deactivatePluginsForPerformance();
+
 	// Audio peak factory accessor.
 	qtractorAudioPeakFactory *audioPeakFactory() const;
 
@@ -403,6 +406,9 @@ public:
 	static qtractorSession *getInstance();
 
 private:
+
+	// check if plugin is not to deactivate for performance
+	bool canTrackMakeSound(qtractorTrack *pTrack); // for now private - maybe helpful for others?
 
 	Properties     m_props;             // Session properties.
 

--- a/src/qtractorSession.h
+++ b/src/qtractorSession.h
@@ -320,6 +320,7 @@ public:
 
 	// Special performance optimized plugin activation
 	void deactivatePluginsForPerformance();
+	void setAutoDeactivatePlugins(bool bOn);
 
 	// Audio peak factory accessor.
 	qtractorAudioPeakFactory *audioPeakFactory() const;
@@ -409,6 +410,8 @@ private:
 
 	// check if plugin is not to deactivate for performance
 	bool canTrackMakeSound(qtractorTrack *pTrack); // for now private - maybe helpful for others?
+	// Restore activation state
+	void undoDeactivatePluginsForPerformance();
 
 	Properties     m_props;             // Session properties.
 
@@ -476,6 +479,9 @@ private:
 
 	// Auto time-stretching global flag (when tempo changes)
 	bool m_bAutoTimeStretch;
+
+	// Auto disable plugins flag
+	bool m_bDeactivatePluginsForPerformance;
 
 	// MIDI plugin manager list.
 	qtractorList<qtractorMidiManager> m_midiManagers;

--- a/src/qtractorTrack.cpp
+++ b/src/qtractorTrack.cpp
@@ -749,6 +749,8 @@ void qtractorTrack::setMonitor ( bool bMonitor )
 	m_props.monitor = bMonitor;
 
 	m_pMonitorSubject->setValue(bMonitor ? 1.0f : 0.0f);
+
+	m_pSession->deactivatePluginsForPerformance();
 }
 
 
@@ -797,6 +799,8 @@ void qtractorTrack::setMute ( bool bMute )
 
 	if (m_pSession->isPlaying() && !bMute)
 		m_pSession->trackMute(this, bMute);
+
+	m_pSession->deactivatePluginsForPerformance();
 }
 
 bool qtractorTrack::isMute (void) const
@@ -821,6 +825,8 @@ void qtractorTrack::setSolo ( bool bSolo )
 
 	if (m_pSession->isPlaying() && !bSolo)
 		m_pSession->trackSolo(this, bSolo);
+
+	m_pSession->deactivatePluginsForPerformance();
 }
 
 bool qtractorTrack::isSolo (void) const


### PR DESCRIPTION
At this at this stage it is ready to publish and ask for comments. 

I have to mention:
* that I am not an enhanced user of qtractor. So it not unlikely that the changes cause other users trouble.
* I have tested the patch series with MIDI tracks only yet

The major intention of this pull request is to get feedback and be informed of stoppers I don't see and if it makes sense to go further in this direction.