### PR TITLE
add option to deactivate plugins only if they can produce sound

### DIFF
--- a/src/qtractorCurve.cpp
+++ b/src/qtractorCurve.cpp
@@ -24,6 +24,8 @@
 
 #include "qtractorTimeScale.h"
 
+#include "qtractorSession.h"
+
 #include <math.h>
 
 
@@ -744,8 +746,14 @@ void qtractorCurve::setCapture ( bool bCapture )
 
 	const bool bOldCapture = (m_state & Capture);
 	m_state = State(bCapture ? (m_state | Capture) : (m_state & ~Capture));
-	if ((bCapture && !bOldCapture) || (!bCapture && bOldCapture))
+	if ((bCapture && !bOldCapture) || (!bCapture && bOldCapture)) {
 		m_pList->updateCapture(bCapture);
+
+		// notify auto-plugin-deactivate
+		qtractorSession *pSession = qtractorSession::getInstance();
+		if (pSession != NULL)
+			pSession->autoPluginsDeactivate();
+	}
 }
 
 
@@ -760,8 +768,14 @@ void qtractorCurve::setProcess ( bool bProcess )
 
 	const bool bOldProcess = (m_state & Process);
 	m_state = State(bProcess ? (m_state | Process) : (m_state & ~Process));
-	if ((bProcess && !bOldProcess) || (!bProcess && bOldProcess))
+	if ((bProcess && !bOldProcess) || (!bProcess && bOldProcess)) {
 		m_pList->updateProcess(bProcess);
+
+		// notify auto-plugin-deactivate
+		qtractorSession *pSession = qtractorSession::getInstance();
+		if (pSession != NULL)
+			pSession->autoPluginsDeactivate();
+	}
 }
 
 

--- a/src/qtractorMainForm.h
+++ b/src/qtractorMainForm.h
@@ -178,6 +178,7 @@ public slots:
 	void trackHeightDown();
 	void trackHeightReset();
 	void trackAutoMonitor(bool bOn);
+	void trackAutoDeactivatePlugins(bool bOn);
 	void trackImportAudio();
 	void trackImportMidi();
 	void trackExportAudio();

--- a/src/qtractorMainForm.ui
+++ b/src/qtractorMainForm.ui
@@ -318,6 +318,7 @@
     <addaction name="trackHeightMenu"/>
     <addaction name="separator"/>
     <addaction name="trackAutoMonitorAction"/>
+    <addaction name="trackAutoDeactivatePluginsAction"/>
     <addaction name="separator"/>
     <addaction name="trackImportMenu"/>
     <addaction name="trackExportMenu"/>
@@ -1439,6 +1440,26 @@
    </property>
    <property name="shortcut">
     <string>F6</string>
+   </property>
+  </action>
+  <action name="trackAutoDeactivatePluginsAction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Auto Deactivate</string>
+   </property>
+   <property name="iconText">
+    <string>Auto Deactivate</string>
+   </property>
+   <property name="toolTip">
+    <string>Auto-deactivate plugins</string>
+   </property>
+   <property name="statusTip">
+    <string>Auto-deactivate plugins not producing sound</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+F6</string>
    </property>
   </action>
   <action name="trackImportAudioAction">

--- a/src/qtractorOptions.cpp
+++ b/src/qtractorOptions.cpp
@@ -198,6 +198,7 @@ void qtractorOptions::loadOptions (void)
 	sMidiControlDir = m_settings.value("/MidiControlDir").toString();
 	sMidiSysexDir   = m_settings.value("/MidiSysexDir").toString();
 	bAutoMonitor    = m_settings.value("/AutoMonitor", true).toBool();
+	bAutoDeactivatePlugins = m_settings.value("/AutoDeactivatePlugins", false).toBool();
 	iSnapPerBeat    = m_settings.value("/SnapPerBeat", 4).toInt();
 	fTempo    = float(m_settings.value("/Tempo", 120.0).toDouble());
 	iBeatsPerBar    = m_settings.value("/BeatsPerBar", 4).toInt();
@@ -489,6 +490,7 @@ void qtractorOptions::saveOptions (void)
 	m_settings.setValue("/MidiControlDir", sMidiControlDir);
 	m_settings.setValue("/MidiSysexDir", sMidiSysexDir);
 	m_settings.setValue("/AutoMonitor", bAutoMonitor);
+	m_settings.setValue("/AutoDeactivatePlugins", bAutoDeactivatePlugins);
 	m_settings.setValue("/SnapPerBeat", iSnapPerBeat);
 	m_settings.setValue("/Tempo", double(fTempo));
 	m_settings.setValue("/BeatsPerBar", iBeatsPerBar);

--- a/src/qtractorOptions.h
+++ b/src/qtractorOptions.h
@@ -169,6 +169,7 @@ public:
 	bool    bSessionBackup;
 	int     iSessionBackupMode;
 	bool	bAutoMonitor;
+	bool	bAutoDeactivatePlugins;
 	int     iSnapPerBeat;
 	float   fTempo;
 	int     iBeatsPerBar;

--- a/src/qtractorPlugin.h
+++ b/src/qtractorPlugin.h
@@ -361,10 +361,13 @@ public:
 	unsigned long uniqueID() const
 		{ return m_iUniqueID; }
 
+	// Activation additional info sender supplies.
+	enum ActivationInfoType { Default, Create, Copy, SaveSession };
+
 	// Activation methods.
-	void setActivated(bool bActivated);
+	void setActivated(bool bActivated, ActivationInfoType info = Default);
 	void setActivatedEx(bool bActivated);
-	bool isActivated() const;
+	bool isActivated(ActivationInfoType info = Default) const;
 
 	// Activate subject accessors.
 	qtractorSubject *activateSubject()
@@ -645,6 +648,9 @@ public:
 	// Parameter update executive.
 	void updateParamValue(unsigned long iIndex, float fValue, bool bUpdate);
 
+	// Auto-plugin-deactivation
+	void autoPluginDeactivate(bool bDeactivated);
+	bool canBeConnectedToOtherTracks();
 protected:
 
 	// Instance number settler.
@@ -668,6 +674,9 @@ private:
 
 	// Activation flag.
 	bool m_bActivated;
+
+	// Auto-plugin-deactivation flag
+	bool m_bAutoDeactivated;
 
 	// Activate subject value.
 	qtractorSubject m_activateSubject;
@@ -914,6 +923,10 @@ public:
 	bool isAudioInsertActivated() const
 		{ return (m_iAudioInsertActivated > 0); }
 
+	// Special auto-deactivate methods
+	void autoPluginDeactivate(bool bDeactivated, bool bForce = false);
+	bool isAutoDeactivated();
+
 protected:
 
 	// Check/sanitize plugin file-path.
@@ -961,6 +974,9 @@ private:
 
 	// Plugin registry (chain unique ids.)
 	QHash<unsigned long, unsigned int> m_uniqueIDs;
+
+	// Auto-plugin-deactivation
+	bool m_bAutoDeactivate;
 };
 
 

--- a/src/qtractorPluginListView.cpp
+++ b/src/qtractorPluginListView.cpp
@@ -540,7 +540,7 @@ void qtractorPluginListView::addPlugin (void)
 				selectForm.pluginIndex(i),
 				selectForm.pluginTypeHint(i));
 		if (pPlugin) {
-			pPlugin->setActivated(selectForm.isPluginActivated());
+			pPlugin->setActivated(selectForm.isPluginActivated(), qtractorPlugin::Create);
 			pAddPluginCommand->addPlugin(pPlugin);
 		}
 	}
@@ -1631,25 +1631,26 @@ void qtractorPluginListView::contextMenuEvent (
 	pAction->setEnabled(bMidiInsertPlugin);
 	menu.addSeparator();
 
+	const bool bAutoDeactivated = m_pPluginList->isAutoDeactivated();
 	pAction = menu.addAction(
 		tr("Ac&tivate"), this, SLOT(activatePlugin()));
 	pAction->setCheckable(true);
 	pAction->setChecked(pPlugin && pPlugin->isActivated());
-	pAction->setEnabled(pPlugin != NULL);
+	pAction->setEnabled(pPlugin && !bAutoDeactivated);
 
 	const bool bActivatedAll = m_pPluginList->isActivatedAll();
 	pAction = menu.addAction(
 		tr("Acti&vate All"), this, SLOT(activateAllPlugins()));
 	pAction->setCheckable(true);
 	pAction->setChecked(bActivatedAll);
-	pAction->setEnabled(bEnabled && !bActivatedAll);
+	pAction->setEnabled(bEnabled && !bActivatedAll && !bAutoDeactivated);
 
 	const bool bDeactivatedAll = !m_pPluginList->isActivated();
 	pAction = menu.addAction(
 		tr("Deactivate Al&l"), this, SLOT(deactivateAllPlugins()));
 	pAction->setCheckable(true);
 	pAction->setChecked(bDeactivatedAll);
-	pAction->setEnabled(bEnabled && !bDeactivatedAll);
+	pAction->setEnabled(bEnabled && !bDeactivatedAll && !bAutoDeactivated);
 
 	menu.addSeparator();
 

--- a/src/qtractorSession.h
+++ b/src/qtractorSession.h
@@ -318,6 +318,11 @@ public:
 	void trackMute(qtractorTrack *pTrack, bool bMute);
 	void trackSolo(qtractorTrack *pTrack, bool bSolo);
 
+	// Special auto-plugin-deactivation
+	void autoPluginsDeactivate(bool bForce = false);
+	void setAutoDeactivatePlugins(bool bOn);
+	bool getAutoDeactivatePlugins();
+
 	// Audio peak factory accessor.
 	qtractorAudioPeakFactory *audioPeakFactory() const;
 
@@ -404,6 +409,11 @@ public:
 
 private:
 
+	// check if plugin can be auto deactivated
+	bool canTrackBeAutoDeactivated(qtractorTrack *pTrack); // for now private - maybe helpful for others?
+	// Restore activation state
+	void undoAutoPluginsDeactivate();
+
 	Properties     m_props;             // Session properties.
 
 	unsigned long  m_iSessionStart;     // Session start in frames.
@@ -470,6 +480,9 @@ private:
 
 	// Auto time-stretching global flag (when tempo changes)
 	bool m_bAutoTimeStretch;
+
+	// Auto disable plugins flag
+	bool m_bAutoDeactivatePlugins;
 
 	// MIDI plugin manager list.
 	qtractorList<qtractorMidiManager> m_midiManagers;

--- a/src/qtractorTrack.cpp
+++ b/src/qtractorTrack.cpp
@@ -749,6 +749,8 @@ void qtractorTrack::setMonitor ( bool bMonitor )
 	m_props.monitor = bMonitor;
 
 	m_pMonitorSubject->setValue(bMonitor ? 1.0f : 0.0f);
+
+	m_pSession->autoPluginsDeactivate();
 }
 
 
@@ -797,6 +799,8 @@ void qtractorTrack::setMute ( bool bMute )
 
 	if (m_pSession->isPlaying() && !bMute)
 		m_pSession->trackMute(this, bMute);
+
+	m_pSession->autoPluginsDeactivate();
 }
 
 bool qtractorTrack::isMute (void) const
@@ -821,6 +825,8 @@ void qtractorTrack::setSolo ( bool bSolo )
 
 	if (m_pSession->isPlaying() && !bSolo)
 		m_pSession->trackSolo(this, bSolo);
+
+	m_pSession->autoPluginsDeactivate();
 }
 
 bool qtractorTrack::isSolo (void) const


### PR DESCRIPTION
Have reworked so that auto-plugin-deactivate is less aggressive:

* **automation**: A track playing/recording automation cannot be auto-deactivated
* **inserts**: Inserts/Aux-Sends and all plugins above are not auto-deactivated. To test I have moved around/created plugins a lot
* **export/freewheeling**: As soon as audio export is selected the whole auto-deactivation is disabled until dialog is closed (for cancel or export done)