### PR TITLE
Auto-Deactivation: Fix broken activation of new tracks

### DIFF
--- a/src/qtractorPlugin.cpp
+++ b/src/qtractorPlugin.cpp
@@ -299,19 +299,14 @@ void qtractorPlugin::setInstances ( unsigned short iInstances )
 // Activation methods.
 
 // immediate
-void qtractorPlugin::setActivated (bool bActivated, ActivationInfo info )
+void qtractorPlugin::setActivated (bool bActivated)
 {
-	// ensure not to forget initial activation
-	// if created as auto-deactivated...
-	if (info == Create)
-		m_bActivated = bActivated;
-
 	updateActivated(bActivated);
 
 	m_activateObserver.setValue(bActivated ? 1.0f : 0.0f);
 }
 
-// queed (GUI invocation)
+// queued (GUI invocation)
 void qtractorPlugin::setActivatedEx ( bool bActivated )
 {
 	m_activateSubject.setValue(bActivated ? 1.0f : 0.0f);
@@ -358,6 +353,7 @@ bool qtractorPlugin::canBeConnectedToOtherTracks (void) const
 void qtractorPlugin::updateActivated ( bool bActivated )
 {
 	if (bActivated != m_bActivated) {
+		m_bActivated = bActivated;
 		const bool bIsConnectedToOtherTracks = canBeConnectedToOtherTracks();
 		// Auto-plugin-deactivation overrides standard-activation for plugins
 		// without connections to other tracks (Inserts/AuxSends)
@@ -367,7 +363,6 @@ void qtractorPlugin::updateActivated ( bool bActivated )
 				activate();
 			else
 				deactivate();
-			m_bActivated = bActivated;
 			m_pList->updateActivated(bActivated);
 		}
 		// Plugins connected to other tracks activation change

--- a/src/qtractorPlugin.h
+++ b/src/qtractorPlugin.h
@@ -362,10 +362,10 @@ public:
 		{ return m_iUniqueID; }
 
 	// Activation additional info sender supplies.
-	enum ActivationInfo { Default = 0, Create, Copy, Save };
+	enum ActivationInfo { Default = 0, Copy, Save };
 
 	// Activation methods.
-	void setActivated(bool bActivated, ActivationInfo info = Default);
+	void setActivated(bool bActivated);
 	void setActivatedEx(bool bActivated);
 	bool isActivated(ActivationInfo info = Default) const;
 

--- a/src/qtractorPluginListView.cpp
+++ b/src/qtractorPluginListView.cpp
@@ -540,7 +540,7 @@ void qtractorPluginListView::addPlugin (void)
 				selectForm.pluginIndex(i),
 				selectForm.pluginTypeHint(i));
 		if (pPlugin) {
-			pPlugin->setActivated(selectForm.isPluginActivated(), qtractorPlugin::Create);
+			pPlugin->setActivated(selectForm.isPluginActivated());
 			pAddPluginCommand->addPlugin(pPlugin);
 		}
 	}


### PR DESCRIPTION
Part of the changes made at auto-deactivation were reverted. The idea of
modified activation was to reduce plugin-activation because at the time of
making auto-deactivation tests were made with buggy fluidsynth-dssi. That
caused segfaults on multiple activation/deactivation.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>