### PR TITLE
Enhance midi import

### DIFF
--- a/src/qtractorMainForm.cpp
+++ b/src/qtractorMainForm.cpp
@@ -76,6 +76,8 @@
 #include "qtractorMidiEditorForm.h"
 #include "qtractorMidiEditor.h"
 
+#include "qtractorMidiImportExtender.h"
+
 #include "qtractorTrackCommand.h"
 #include "qtractorCurveCommand.h"
 
@@ -3833,9 +3835,15 @@ void qtractorMainForm::trackImportMidi (void)
 	if (m_pTracks) {
 		const unsigned long iClipStart = m_pSession->editHead();
 		qtractorTrack *pTrack = m_pTracks->currentTrack();
-		m_pTracks->addMidiTracks(
-			m_pFiles->midiListView()->openFileNames(), iClipStart, pTrack);
-		m_pTracks->trackView()->ensureVisibleFrame(iClipStart);
+
+		QStringList files;
+		files = m_pFiles->midiListView()->openFileNames();
+		if (!files.isEmpty()) {
+			qtractorMidiImportExtender midiImportExtenter;
+			m_pTracks->addMidiTracks(
+				files, iClipStart, pTrack, &midiImportExtenter);
+			m_pTracks->trackView()->ensureVisibleFrame(iClipStart);
+		}
 	}
 }
 

--- a/src/qtractorMidiImportExtender.cpp
+++ b/src/qtractorMidiImportExtender.cpp
@@ -1,0 +1,462 @@
+// qtractorMidiImportExtender.cpp
+//
+/****************************************************************************
+   Copyright (C) 2005-2017, rncbc aka Rui Nuno Capela. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#include "qtractorMidiImportExtender.h"
+#include "qtractorSession.h"
+#include "qtractorPlugin.h"
+#include "qtractorOptions.h"
+#include "qtractorPluginListDocument.h"
+#include "qtractorAudioEngine.h"
+#include "qtractorMidiEngine.h"
+#include "qtractorMidiManager.h"
+#include "qtractorTrackCommand.h"
+#include "qtractorMidiClip.h"
+#include <QDomDocument>
+#include <QElapsedTimer>
+
+//----------------------------------------------------------------------
+// class qtractorMidiImportExtender -- MIDI import extender class.
+//
+
+//
+// It is not a good idea to delete plugins: At least DSSI plugins supporting
+// run_multiple_synths interface get confused and cause crashes when deleting.
+//
+// To avoid deletion of plugins the plugins are kept in static m_pPluginList
+// which is created as soon as pluginList() is called (typically by settings
+// dialog).
+// At MIDI import process the plugins in plugin list are reused by moving to
+// first track generated to avoid wasting resources.
+//
+
+
+// Pointer to singleton plugin list for display.
+qtractorPluginList *qtractorMidiImportExtender::m_pPluginList = NULL;
+// Keep info that plugin list was empied.
+bool qtractorMidiImportExtender::m_bPluginListIsEmpty = true;
+
+// Constructor.
+qtractorMidiImportExtender::qtractorMidiImportExtender()
+{
+	// Get global session object
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (!pSession)
+		return;
+	// Get global options object
+	qtractorOptions *pOptions = qtractorOptions::getInstance();
+	if (!pOptions)
+		return;
+
+	// Keep a shadow copy of settings.
+	if (!pOptions->sMidiImportPlugins.isEmpty()) {
+		m_extendedSettings.pPluginDomDocument = new QDomDocument("qtractorMidiImport");
+		m_extendedSettings.pPluginDomDocument->setContent(pOptions->sMidiImportPlugins);
+	} else
+		m_extendedSettings.pPluginDomDocument = NULL;
+	m_extendedSettings.sMidiImportInstInst = pOptions->sMidiImportInstInst;
+	m_extendedSettings.sMidiImportDrumInst = pOptions->sMidiImportDrumInst;
+	m_extendedSettings.iMidiImportInstBank = pOptions->iMidiImportInstBank;
+	m_extendedSettings.iMidiImportDrumBank = pOptions->iMidiImportDrumBank;
+	m_extendedSettings.eMidiImportTrackNameType = (TrackNameType) pOptions->iMidiImportTrackName;
+
+	// Get reference of the last command before dialog.
+	m_pLastUndoCommand = NULL;
+	qtractorCommandList *pCommands = pSession->commands();
+	if (pCommands)
+		m_pLastUndoCommand = pCommands->lastCommand();
+
+	// Setup track number here. When setting track name, imported tracks are
+	// already created.
+	m_iTrackNumber = pSession->tracks().count();
+
+	m_bAutoDeactivateWasDisabled = false;
+}
+
+
+// Destructor.
+qtractorMidiImportExtender::~qtractorMidiImportExtender()
+{
+	// cleanup document
+	if (m_extendedSettings.pPluginDomDocument)
+		delete m_extendedSettings.pPluginDomDocument;
+}
+
+
+// Save all settings to global options.
+void qtractorMidiImportExtender::saveSettings()
+{
+	// Get global options object
+	qtractorOptions *pOptions = qtractorOptions::getInstance();
+	if (!pOptions)
+		return;
+
+	// Xmlize plugin list and store in options
+	pluginListToDocument();
+	QString strPluginListXML;
+	if (m_extendedSettings.pPluginDomDocument)
+		// Store as XML string without whitespaces.
+		strPluginListXML = m_extendedSettings.pPluginDomDocument->toString(-1);
+	pOptions->sMidiImportPlugins = strPluginListXML;
+
+	// Store other options
+	pOptions->sMidiImportInstInst = m_extendedSettings.sMidiImportInstInst;
+	pOptions->sMidiImportDrumInst = m_extendedSettings.sMidiImportDrumInst;
+	pOptions->iMidiImportInstBank = m_extendedSettings.iMidiImportInstBank;
+	pOptions->iMidiImportDrumBank = m_extendedSettings.iMidiImportDrumBank;
+	pOptions->iMidiImportTrackName = (int)m_extendedSettings.eMidiImportTrackNameType;
+}
+
+
+// Undo commands done since creation (for CANCEL on dialog).
+void qtractorMidiImportExtender::backoutCommandList()
+{
+	// Backout all commands made in this dialog-session.
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession)
+		pSession->commands()->backout(m_pLastUndoCommand);
+}
+
+
+// Restore undo command list to the point of creation without performing
+// plugin list actions. Do this to avoid commands added to undo menu (for OK
+// on dialogs).
+void qtractorMidiImportExtender::restoreCommandList()
+{
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession) {
+		qtractorCommandList *pCommands = pSession->commands();
+		// Remove all commands without execution - tested: command list keeps
+		// them with proper auto-delete so they are cleaned up properly on
+		// session close.
+		for (qtractorCommand *pCurrLastCommand = pCommands->lastCommand();
+			pCurrLastCommand != m_pLastUndoCommand;
+			pCurrLastCommand = pCommands->lastCommand())
+			pCommands->removeLastCommand();
+	}
+}
+
+
+// Accessor/creator for plugin list.
+qtractorPluginList *qtractorMidiImportExtender::pluginListForGui()
+{
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (!pSession)
+		return NULL;
+
+	// Create plugin list.
+	if (!m_pPluginList) {
+		m_pPluginList = new qtractorPluginList(0, qtractorPluginList::Midi);
+		// GUI plugin list will never be heard so do no processing.
+		m_pPluginList->forceNoProcessing(true);
+	}
+	// Were plugins removed?
+	if (m_bPluginListIsEmpty) {
+		// Create plugins from document.
+		if (m_extendedSettings.pPluginDomDocument) {
+			qtractorPluginListDocument pluginListDocument(
+						m_extendedSettings.pPluginDomDocument,
+						m_pPluginList);
+			// Get root element and check for proper taq name.
+			QDomElement elem = m_extendedSettings.pPluginDomDocument->documentElement();
+			if (elem.tagName() == "PluginList") {
+				pluginListDocument.loadElement(&elem);
+			}
+		}
+		// Plugin list needs channels set > 0. Otherwise all entries in
+		// plugin selection dialog are disabled. Try same channel count as
+		// master output audio bus. That is default connection for imported
+		// tracks.
+		qtractorAudioBus *pAudioBus = NULL;
+		qtractorAudioEngine *pAudioEngine = pSession->audioEngine();
+		for (qtractorBus *pBus = (pAudioEngine->buses()).first();
+				pBus; pBus = pBus->next()) {
+			if (pBus->busMode() & qtractorBus::Output) {
+				pAudioBus = static_cast<qtractorAudioBus *> (pBus);
+				break;
+			}
+		}
+		if (pAudioBus)
+			m_pPluginList->setChannels(pAudioBus->channels(),
+					qtractorPluginList::Midi);
+		else
+			// Use reasonable fallback channel count.
+			m_pPluginList->setChannels(2, qtractorPluginList::Midi);
+		// Plugin list is filled now.
+		m_bPluginListIsEmpty = false;
+	}
+
+	return m_pPluginList;
+}
+
+
+// Clear singleton plugin list and delete plugins
+void qtractorMidiImportExtender::clearPluginList()
+{
+	if (m_pPluginList) {
+		delete m_pPluginList;
+		m_pPluginList = NULL;
+	}
+	m_bPluginListIsEmpty = true;
+}
+
+
+// Add plugins to track - this must be done before track is added to session.
+// There was no way found to wait for plugins e.g. loading soundfonts.
+void qtractorMidiImportExtender::prepareTrackForExtension(qtractorTrack *pTrack)
+{
+	// Are there plugins to add ?
+	if (m_extendedSettings.pPluginDomDocument) {
+
+		// Bail out if something is wrong.
+		if (!pTrack)
+			return;
+		qtractorSession *pSession = qtractorSession::getInstance();
+		if (!pSession)
+			return;
+		qtractorPluginList *pPluginList = pTrack->pluginList();
+		if (!pPluginList)
+			return;
+
+		// Auto deactivation must be disabled to make plugins process program/bank
+		// changes.
+		if (!m_bAutoDeactivateWasDisabled && pSession->isAutoDeactivatePlugins()) {
+			pSession->setAutoDeactivatePlugins(false);
+			m_bAutoDeactivateWasDisabled = true;
+		}
+
+		// Deactivate processing for plugin list - we have to choose the hard way
+		// because during adding tracks to session activation state of plugins
+		// flip. It seems activated plugins must report proper activation state
+		// for next actions - otherwise output is scrambled.
+		pPluginList->forceNoProcessing(true);
+
+		// Add plugins early. Several options were tested to add plugins later
+		// (when tracks are complete / added to session): it was not possible to
+		// set patch reproducable.
+
+		// Take plugins for first track from plugin list.
+		if (m_pPluginList && !m_bPluginListIsEmpty)
+		{
+			// Move plugins to target.
+			while (m_pPluginList->count())
+				pPluginList->movePlugin(m_pPluginList->first(), NULL);
+			m_bPluginListIsEmpty = true;
+		}
+		// All further are cloned by our document - if there is one.
+		else {
+			// Get root element and check for proper taq name.
+			QDomElement elem =
+					m_extendedSettings.pPluginDomDocument->documentElement();
+			if (elem.tagName() == "PluginList") {
+				qtractorPluginListDocument pluginListDocument(
+							m_extendedSettings.pPluginDomDocument, pPluginList);
+				pluginListDocument.loadElement(&elem);
+			}
+		}
+	}
+}
+
+
+// Set instrument and track-name. Tracks must be 'complete' (have an output bus).
+bool qtractorMidiImportExtender::finishTracksForExtension(
+		QList<qtractorTrack *> *pImportedTracks)
+{
+	// Bail out if something is wrong.
+	if (!pImportedTracks || pImportedTracks->count() == 0)
+		return false;
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (!pSession)
+		return false;
+
+	qtractorTrack *pTrack;
+
+	// Were plugins added?
+	if (m_extendedSettings.pPluginDomDocument) {
+		// Loop all tracks to wake plugins.
+		for (pTrack = pImportedTracks->first(); pTrack; pTrack = pTrack->next()) {
+			qtractorPluginList *pPluginList = pTrack->pluginList();
+			if (!pPluginList)
+				continue;
+			if (pPluginList->count() > 0)
+				pPluginList->forceNoProcessing(false);
+		}
+
+		// Make sure plugins are able to process program/bank changes send below.
+		pSession->stabilize(100);
+	}
+
+	// Return value notifying import process of changes done here.
+	bool bOneOrMoreTracksChanged = false;
+
+	// Loop all tracks to set patches.
+	for (pTrack = pImportedTracks->first(); pTrack; pTrack = pTrack->next()) {
+
+		qtractorPluginList *pPluginList = pTrack->pluginList();
+		if (!pPluginList)
+			continue;
+
+		// Get current track properties.
+		qtractorTrack::Properties &properties = pTrack->properties();
+		bool bIsDrumTrack = properties.midiChannel == 9;
+
+		// Midi bank.
+		int iBankNew = properties.midiBank;
+		if (!bIsDrumTrack) {
+			// Instruments: apply bank settings only if clip does not suggest.
+			if (iBankNew < 0)
+				iBankNew = m_extendedSettings.iMidiImportInstBank;
+		} else
+			// Follow settings for drums whatever clip suggests.
+			iBankNew = m_extendedSettings.iMidiImportDrumBank;
+		// And bank action...
+		if (iBankNew >= 0) {
+			// By default midiBankSelMethod is -1. If not set it here, bank change
+			// is not send to instrument.
+			properties.midiBankSelMethod = 0;
+			properties.midiBank = iBankNew;
+			bOneOrMoreTracksChanged = true;
+		}
+
+		// Midi prog.
+		// Special case for drum-tracks program: Some MIDI files out in the wild do
+		// not set program for drum tracks. Give those a reasonable default.
+		if (bIsDrumTrack && properties.midiProg < 0) {
+			// Set standard drums.
+			properties.midiProg = 0;
+			bOneOrMoreTracksChanged = true;
+		}
+
+		// Instrument.
+		QString strInstrumentNew = bIsDrumTrack ?
+				m_extendedSettings.sMidiImportDrumInst :
+				m_extendedSettings.sMidiImportInstInst;
+		if (!strInstrumentNew.isEmpty())
+			bOneOrMoreTracksChanged = true;
+
+		// Do set patch (instrument / midiprog / midibank).
+		qtractorMidiBus *pMidiBus =
+			static_cast<qtractorMidiBus *> (pTrack->outputBus());
+		if (pMidiBus) {
+			if (properties.midiProg >= 0) {
+				pMidiBus->setPatch(properties.midiChannel,
+					strInstrumentNew,
+					properties.midiBankSelMethod,
+					properties.midiBank,
+					properties.midiProg,
+					pTrack);
+			}
+		}
+
+		// Create track name.  Set names only for tracks making noise after
+		// import. This indicates from first glance that track is special or
+		// broken or...
+		QString sTrackName;
+		if (pTrack->midiBank() >= 0 && pTrack->midiProg() >= 0) {
+			// Set track name based upon type set up.
+			switch (m_extendedSettings.eMidiImportTrackNameType) {
+			case Midifile:
+				// MIDI filename is default: no modification.
+				break;
+			case Track:
+				sTrackName = pSession->uniqueTrackName(
+						QString("Track %1").arg(++m_iTrackNumber));
+				break;
+			case PatchName:
+				// Instrument track.
+				if (!bIsDrumTrack) {
+					// Collect what's necessary to get patch name.
+					qtractorMidiManager *pMidiManager = pPluginList->midiManager();
+					if (!pMidiManager)
+						break;
+
+					const qtractorMidiManager::Instruments& list
+						= pMidiManager->instruments();
+					QString sInstrumentName = m_extendedSettings.sMidiImportInstInst;
+					if (!list.contains(sInstrumentName))
+						break;
+
+					const qtractorMidiManager::Banks& banks
+						= list[sInstrumentName];
+					if (!banks.contains(pTrack->midiBank()))
+						break;
+
+					// A patch name was found!
+					const qtractorMidiManager::Progs& progs = banks[pTrack->midiBank()].progs;
+					sTrackName = progs[pTrack->midiProg()];
+				}
+
+				// Drum track's name is fixed - patch names are not really useful at drums.
+				else
+					sTrackName = QObject::tr("Drums");
+				break;
+			}
+		}
+
+		// Do set track name.
+		if (!sTrackName.isEmpty()) {
+			properties.trackName = sTrackName;
+			pSession->releaseTrackName(pTrack);
+			pTrack->setTrackName(sTrackName);
+			pSession->acquireTrackName(pTrack);
+			bOneOrMoreTracksChanged = true;
+		}
+
+		// Apply all to track also.
+		pTrack->setProperties(properties);
+	}
+
+	// Restore plugin auto deactivation.
+	if (m_bAutoDeactivateWasDisabled) {
+		pSession->setAutoDeactivatePlugins(true);
+		m_bAutoDeactivateWasDisabled = false;
+	}
+	return bOneOrMoreTracksChanged;
+}
+
+
+// Accessor to extended settings.
+qtractorMidiImportExtender::exportExtensionsData *qtractorMidiImportExtender::exportExtensions()
+{
+	return &m_extendedSettings;
+}
+
+
+// Xmlize plugin list.
+void qtractorMidiImportExtender::pluginListToDocument()
+{
+	// Remove old plugin list document.
+	if (m_extendedSettings.pPluginDomDocument) {
+		delete m_extendedSettings.pPluginDomDocument;
+		m_extendedSettings.pPluginDomDocument = NULL;
+	}
+
+	if (m_pPluginList && m_pPluginList->count()) {
+		// Save plugin settings to new document.
+		m_extendedSettings.pPluginDomDocument = new QDomDocument("qtractorMidiImport");
+		qtractorPluginListDocument pluginListDocument(m_extendedSettings.pPluginDomDocument, m_pPluginList);
+		QDomElement elem = m_extendedSettings.pPluginDomDocument->createElement("PluginList");
+		m_pPluginList->saveElement(&pluginListDocument, &elem);
+		m_extendedSettings.pPluginDomDocument->appendChild(elem);
+	}
+}
+
+
+// end of qtractorMidiImportExtender.cpp

--- a/src/qtractorMidiImportExtender.cpp
+++ b/src/qtractorMidiImportExtender.cpp
@@ -369,7 +369,7 @@ bool qtractorMidiImportExtender::finishTracksForExtension(
 		// import. This indicates from first glance that track is special or
 		// broken or...
 		QString sTrackName;
-		if (pTrack->midiBank() >= 0 && pTrack->midiProg() >= 0) {
+		if (properties.midiBank >= 0 && properties.midiProg >= 0) {
 			// Set track name based upon type set up.
 			switch (m_extendedSettings.eMidiImportTrackNameType) {
 			case Midifile:
@@ -395,12 +395,12 @@ bool qtractorMidiImportExtender::finishTracksForExtension(
 
 					const qtractorMidiManager::Banks& banks
 						= list[sInstrumentName];
-					if (!banks.contains(pTrack->midiBank()))
+					if (!banks.contains(properties.midiBank))
 						break;
 
 					// A patch name was found!
-					const qtractorMidiManager::Progs& progs = banks[pTrack->midiBank()].progs;
-					sTrackName = progs[pTrack->midiProg()];
+					const qtractorMidiManager::Progs& progs = banks[properties.midiBank].progs;
+					sTrackName = progs[properties.midiProg];
 				}
 
 				// Drum track's name is fixed - patch names are not really useful at drums.

--- a/src/qtractorMidiImportExtender.cpp
+++ b/src/qtractorMidiImportExtender.cpp
@@ -338,11 +338,12 @@ bool qtractorMidiImportExtender::finishTracksForExtension(
 		// Midi prog.
 		// Special case for drum-tracks program: Some MIDI files out in the wild do
 		// not set program for drum tracks. Give those a reasonable default.
-		if (bIsDrumTrack && properties.midiProg < 0) {
+		if (bIsDrumTrack && properties.midiProg < 0)
 			// Set standard drums.
 			properties.midiProg = 0;
+		// Initial program change was missed likely (plugins did not process).
+		if (properties.midiProg >= 0)
 			bOneOrMoreTracksChanged = true;
-		}
 
 		// Instrument.
 		QString strInstrumentNew = bIsDrumTrack ?

--- a/src/qtractorMidiImportExtender.h
+++ b/src/qtractorMidiImportExtender.h
@@ -1,0 +1,109 @@
+// qtractorMidiImportExtender.h
+//
+/****************************************************************************
+   Copyright (C) 2005-2017, rncbc aka Rui Nuno Capela. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#ifndef __qtractorMidiImportExtender_h
+#define __qtractorMidiImportExtender_h
+
+#include <QString>
+#include <QSet>
+
+// forward decalarations.
+class qtractorSession;
+class qtractorPlugin;
+class qtractorPluginList;
+class qtractorPluginListDocument;
+class qtractorEditTrackCommand;
+class qtractorTrack;
+class qtractorMidiClip;
+class qtractorCommand;
+class QDomDocument;
+
+
+class qtractorMidiImportExtender
+{
+public:
+	// Constructor.
+	qtractorMidiImportExtender();
+	// Destructor.
+	virtual ~qtractorMidiImportExtender();
+
+	// Save all settings to global options.
+	void saveSettings();
+	// Undo plugin list commands done since creation.
+	void backoutCommandList();
+	// Restore plugin list command list to the point of creation.
+	void restoreCommandList();
+
+	// Accessor/creator for GUI plugin list.
+	qtractorPluginList *pluginListForGui();
+	// Clear GUI singleton plugin list - do only call on session close!!!
+	static void clearPluginList();
+
+	// Methods used during import.
+	void prepareTrackForExtension(qtractorTrack *pTrack);
+	bool finishTracksForExtension(QList<qtractorTrack *> *pImportedTracks);
+
+	// Track name set types.
+	typedef enum { Midifile, Track, PatchName } TrackNameType;
+
+	// Declare all extended settings for MIDI import.
+	typedef struct{
+		// Plugin list.
+		QDomDocument *pPluginDomDocument;
+		// Instruments to set.
+		QString sMidiImportInstInst;
+		QString sMidiImportDrumInst;
+		// Banks to set
+		int iMidiImportInstBank;
+		int iMidiImportDrumBank;
+		// Type of track name to set.
+		TrackNameType eMidiImportTrackNameType;
+	}  exportExtensionsData;
+
+	// Accessor to exteneded settings.
+	exportExtensionsData *exportExtensions();
+	// Keep auto-deactivation change
+	bool m_bAutoDeactivateWasDisabled;
+
+private:
+
+	// XMLize plugin List
+	void pluginListToDocument();
+
+	// Pointer to singleton plugin list for display.
+	static qtractorPluginList *m_pPluginList;
+	// Keep info that plugin list was empied.
+	static bool m_bPluginListIsEmpty;
+
+	// Settings member.
+	exportExtensionsData m_extendedSettings;
+
+	// Keep last command for backout / restore.
+	qtractorCommand *m_pLastUndoCommand;
+
+	// Track number for 'Track n' naming type.
+	int m_iTrackNumber;
+
+};
+
+#endif // __qtractorMidiImportExtender_h
+
+// end of qtractorMidiImportExtender.h

--- a/src/qtractorMidiImportForm.cpp
+++ b/src/qtractorMidiImportForm.cpp
@@ -1,0 +1,519 @@
+// qtractorMidiListView.cpp
+//
+/****************************************************************************
+   Copyright (C) 2005-2017, rncbc aka Rui Nuno Capela. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#include "qtractorMidiImportForm.h"
+#include "qtractorSession.h"
+#include "qtractorMidiImportExtender.h"
+#include "qtractorMainForm.h"
+#include "qtractorPlugin.h"
+#include "qtractorMidiManager.h"
+#include "qtractorFiles.h"
+#include "qtractorCommand.h"
+#include "qtractorInstrument.h"
+#include "QPushButton"
+
+
+//----------------------------------------------------------------------
+// class qtractorMidiImportForm -- UI wrapper form.
+//
+
+
+// Constructor.
+qtractorMidiImportForm::qtractorMidiImportForm(qtractorMidiImportExtender *pMidiImportExtender,
+		QWidget *pParent, Qt::WindowFlags wflags )
+		: QDialog(pParent, wflags),
+		m_pMidiImportExtender(pMidiImportExtender), m_iDirtySetup(0)
+{
+
+	// Get global session object.
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (!pSession)
+		return;
+
+	// Get plugin list to display.
+	qtractorPluginList *pPluginList = m_pMidiImportExtender->pluginListForGui();
+	if (!pPluginList)
+		return;
+
+	// Setup UI struct...
+	m_ui.setupUi(this);
+
+	// Window modality (let plugin/tool windows rave around).
+	QDialog::setWindowModality(Qt::WindowModal);
+
+	// Get reference of the last command before dialog.
+	m_pLastCommand = NULL;
+	qtractorCommandList *pCommands = pSession->commands();
+	m_pLastCommand = pCommands->lastCommand();
+
+	// Set plugin list...
+	m_ui.PluginListView->setPluginList(pPluginList);
+	m_ui.PluginListView->refresh();
+
+	// Fill Instrument / bank comboboxes.
+	updateInstruments();
+
+	// Get a pointer to settings.
+	qtractorMidiImportExtender::exportExtensionsData *pExtendedSettings =
+			m_pMidiImportExtender->exportExtensions();
+	m_ui.InstInstComboBox->setCurrentText(
+				pExtendedSettings->sMidiImportInstInst);
+	m_ui.DrumInstComboBox->setCurrentText(
+				pExtendedSettings->sMidiImportDrumInst);
+	updateBanks(pExtendedSettings->sMidiImportInstInst,
+				pExtendedSettings->iMidiImportInstBank, Instruments);
+	updateBanks(pExtendedSettings->sMidiImportDrumInst,
+				pExtendedSettings->iMidiImportDrumBank, Drums);
+
+	// Select track-name radio option
+	m_groupNameRadios = new QButtonGroup(this);
+	m_groupNameRadios->addButton(m_ui.NameMidiRadioButton,
+								 (int) qtractorMidiImportExtender::Midifile);
+	m_groupNameRadios->addButton(m_ui.NameTrackRadioButton,
+								 (int) qtractorMidiImportExtender::Track);
+	m_groupNameRadios->addButton(m_ui.NamePatchRadioButton,
+								 (int) qtractorMidiImportExtender::PatchName);
+	QList<QAbstractButton *> radios = m_groupNameRadios->buttons();
+	for (int iRadio = 0; iRadio < radios.count(); ++iRadio) {
+		if (m_groupNameRadios->id(radios[iRadio]) ==
+				(int)pExtendedSettings->eMidiImportTrackNameType) {
+			radios[iRadio]->setChecked(true);
+			break;
+		}
+	}
+
+	// UI signal/slot connections...
+	QObject::connect(m_ui.PluginListView,
+		SIGNAL(currentRowChanged(int)),
+		SLOT(stabilizeListButtons()));
+	QObject::connect(m_ui.PluginListView,
+		SIGNAL(contentsChanged()),
+		SLOT(pluginListChanged()));
+	QObject::connect(m_ui.AddPluginToolButton,
+		SIGNAL(clicked()),
+		SLOT(addPlugin()));
+	QObject::connect(m_ui.RemovePluginToolButton,
+		SIGNAL(clicked()),
+		SLOT(removePlugin()));
+	QObject::connect(m_ui.MoveUpPluginToolButton,
+		SIGNAL(clicked()),
+		SLOT(moveUpPlugin()));
+	QObject::connect(m_ui.MoveDownPluginToolButton,
+		SIGNAL(clicked()),
+		SLOT(moveDownPlugin()));
+
+	QObject::connect(m_ui.InstInstComboBox,
+		SIGNAL(currentIndexChanged(const QString &)),
+		SLOT(changedInstInst(const QString &)));
+	QObject::connect(m_ui.DrumInstComboBox,
+		SIGNAL(currentIndexChanged(const QString &)),
+		SLOT(changedDrumInst(const QString &)));
+	QObject::connect(m_ui.InstBankComboBox,
+		SIGNAL(activated(int)),
+		SLOT(changed()));
+	QObject::connect(m_ui.DrumBankComboBox,
+		SIGNAL(activated(int)),
+		SLOT(changed()));
+	QObject::connect(m_groupNameRadios,
+		SIGNAL(buttonClicked(QAbstractButton *)),
+		SLOT(changed()));
+
+	QObject::connect(m_ui.DialogButtonBox,
+		SIGNAL(accepted()),
+		SLOT(accept()));
+	QObject::connect(m_ui.DialogButtonBox,
+		SIGNAL(rejected()),
+		SLOT(reject()));
+
+	stabilizeListButtons();
+	m_ui.DialogButtonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+}
+
+
+// Destructor.
+qtractorMidiImportForm::~qtractorMidiImportForm()
+{
+}
+
+
+// Accept settings (OK button slot).
+void qtractorMidiImportForm::accept()
+{
+	// Tidy up.
+	commonCleanup();
+
+	// Get a pointer to settings.
+	qtractorMidiImportExtender::exportExtensionsData *pExtendedSettings =
+			m_pMidiImportExtender->exportExtensions();
+
+	// Instrument instruments.
+	QString strInstrument = m_ui.InstInstComboBox->currentText();
+	if (strInstrument == getInstrumentNone())
+		// Avoid language specific options.
+		strInstrument.clear();
+	pExtendedSettings->sMidiImportInstInst = strInstrument;
+
+	// Instrument drums.
+	strInstrument = m_ui.DrumInstComboBox->currentText();
+	if (strInstrument == getInstrumentNone())
+		// Avoid language specific options.
+		strInstrument.clear();
+	pExtendedSettings->sMidiImportDrumInst = strInstrument;
+
+	// Bank instruments.
+	pExtendedSettings->iMidiImportInstBank = -1;
+	int iCurrSelection = m_ui.InstBankComboBox->currentIndex();
+	if (iCurrSelection > 0 && iCurrSelection < m_instBanks.count())
+		pExtendedSettings->iMidiImportInstBank = m_instBanks[iCurrSelection];
+
+	// Bank drums.
+	pExtendedSettings->iMidiImportDrumBank = -1;
+	iCurrSelection = m_ui.DrumBankComboBox->currentIndex();
+	if (iCurrSelection > 0 && iCurrSelection < m_drumBanks.count())
+		pExtendedSettings->iMidiImportDrumBank = m_drumBanks[iCurrSelection];
+
+	// Track name type.
+	pExtendedSettings->eMidiImportTrackNameType =
+			(qtractorMidiImportExtender::TrackNameType)m_groupNameRadios->id(m_groupNameRadios->checkedButton());
+
+	// Just go with dialog acceptance.
+	QDialog::accept();
+}
+
+
+// Reject settings (Cancel button slot).
+void qtractorMidiImportForm::reject()
+{
+	// Tidy up.
+	commonCleanup();
+
+	// Backout all commands made in this dialog-session.
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession)
+		pSession->commands()->backout(m_pLastCommand);
+
+	// Just go away.
+	QDialog::reject();
+}
+
+
+// Stabilize current form state.
+void qtractorMidiImportForm::stabilizeListButtons()
+{
+	// Stabilize current plugin list state.
+	const int iPluginItemCount = m_ui.PluginListView->count();
+	int iPluginItem = -1;
+	qtractorPlugin *pPlugin = NULL;
+	qtractorPluginListItem *pPluginItem
+		= static_cast<qtractorPluginListItem *> (
+			m_ui.PluginListView->currentItem());
+	if (pPluginItem) {
+		iPluginItem = m_ui.PluginListView->row(pPluginItem);
+		pPlugin = pPluginItem->plugin();
+	}
+	m_ui.RemovePluginToolButton->setEnabled(pPlugin != NULL);
+	m_ui.MoveUpPluginToolButton->setEnabled(pPluginItem && iPluginItem > 0);
+	m_ui.MoveDownPluginToolButton->setEnabled(pPluginItem && iPluginItem < iPluginItemCount - 1);
+}
+
+
+void qtractorMidiImportForm::pluginListChanged()
+{
+	updateInstruments();
+	stabilizeListButtons();
+	changed();
+}
+
+
+// Plugin list: add plugin.
+void qtractorMidiImportForm::addPlugin()
+{
+	m_ui.PluginListView->addPlugin();
+	changed();
+}
+
+
+// Plugin list: remove plugin.
+void qtractorMidiImportForm::removePlugin()
+{
+	m_ui.PluginListView->removePlugin();
+	changed();
+}
+
+
+// Plugin list: move plugin up.
+void qtractorMidiImportForm::moveUpPlugin()
+{
+	m_ui.PluginListView->moveUpPlugin();
+	changed();
+}
+
+
+// Plugin list: move plugin down.
+void qtractorMidiImportForm::moveDownPlugin()
+{
+	m_ui.PluginListView->moveDownPlugin();
+	changed();
+}
+
+
+// Instrument for instruments selection changed.
+void qtractorMidiImportForm::changedInstInst( const QString &text )
+{
+	if (m_iDirtySetup > 0)
+		return;
+	updateBanks(text, -1, Instruments);
+	changed();
+}
+
+
+// Instrument for instruments selection changed.
+void qtractorMidiImportForm::changedDrumInst( const QString &text )
+{
+	if (m_iDirtySetup > 0)
+		return;
+	updateBanks(text, -1, Drums);
+	changed();
+}
+
+
+// Settings changed - enable OK
+void qtractorMidiImportForm::changed()
+{
+	m_ui.DialogButtonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+}
+
+
+// Refresh instrument lists
+void qtractorMidiImportForm::updateInstruments()
+{
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession == NULL)
+		return;
+
+	qtractorInstrumentList *pInstruments = pSession->instruments();
+	if (pInstruments == NULL)
+		return;
+
+	++m_iDirtySetup;
+
+	// keep old selections - maybe we can resstore them
+	const QString strOldInstInst = m_ui.InstInstComboBox->currentText();
+	const QString strOldDrumInst = m_ui.DrumInstComboBox->currentText();
+
+	const QIcon& icon = QIcon(":/images/itemInstrument.png");
+	m_ui.InstInstComboBox->clear();
+	m_ui.InstInstComboBox->addItem(getInstrumentNone());
+	m_ui.DrumInstComboBox->clear();
+	m_ui.DrumInstComboBox->addItem(getInstrumentNone());
+
+	// Take care of MIDI plugin instrument names...
+	updateInstrumentsAdd(icon,
+		m_pMidiImportExtender->pluginListForGui()->midiManager());
+
+	// Regular instrument names...
+	qtractorInstrumentList::ConstIterator iter = pInstruments->constBegin();
+	const qtractorInstrumentList::ConstIterator& iter_end = pInstruments->constEnd();
+	for ( ; iter != iter_end; ++iter) {
+
+		m_ui.InstInstComboBox->addItem(icon, iter.value().instrumentName());
+		m_ui.DrumInstComboBox->addItem(icon, iter.value().instrumentName());
+	}
+
+	// Try to restore old instrument selections if possible.
+	m_ui.InstInstComboBox->setCurrentText(strOldInstInst);
+	m_ui.DrumInstComboBox->setCurrentText(strOldDrumInst);
+
+	// In case insrtument has changed: update banks.
+	const QString strNewInstInst = m_ui.InstInstComboBox->currentText();
+	const QString strNewDrumInst = m_ui.DrumInstComboBox->currentText();
+	if (strNewInstInst != strOldInstInst)
+		updateBanks(strNewInstInst, -1, Instruments);
+	if (strNewDrumInst != strOldDrumInst)
+		updateBanks(strNewDrumInst, -1, Drums);
+
+	--m_iDirtySetup;
+}
+
+
+// Refresh instrument lists of given MIDI buffer manager.
+void qtractorMidiImportForm::updateInstrumentsAdd( const QIcon &icon,
+	qtractorMidiManager *pMidiManager )
+{
+	if (pMidiManager == NULL)
+		return;
+
+	pMidiManager->updateInstruments();
+
+	const qtractorMidiManager::Instruments& list
+		= pMidiManager->instruments();
+	qtractorMidiManager::Instruments::ConstIterator iter = list.constBegin();
+	const qtractorMidiManager::Instruments::ConstIterator& iter_end = list.constEnd();
+	for ( ; iter != iter_end; ++iter) {
+		m_ui.InstInstComboBox->addItem(icon, iter.key());
+		m_ui.DrumInstComboBox->addItem(icon, iter.key());
+	}
+}
+
+// Refresh instrument banks lists.
+void qtractorMidiImportForm::updateBanks(
+		const QString &sInstrumentName, int iBank, enum BankType bankType )
+{
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession == NULL)
+		return;
+
+	qtractorInstrumentList *pInstruments = pSession->instruments();
+	if (pInstruments == NULL)
+		return;
+
+	// Default (none) patch bank list...
+	QComboBox *pComboBox = NULL;
+	QMap<int, int> *pBankMap = NULL;
+	switch (bankType) {
+	case Instruments:
+		pComboBox = m_ui.InstBankComboBox;
+		pBankMap = &m_instBanks;
+		break;
+	case Drums:
+		pComboBox = m_ui.DrumBankComboBox;
+		pBankMap = &m_drumBanks;
+		break;
+	}
+	// Should not happen at all...
+	if (!pComboBox || !pBankMap)
+		return;
+
+	// keep old selections - maybe we can resstore them
+	const QString strOldBank = pComboBox->currentText();
+
+	const QIcon& icon = QIcon(":/images/itemPatches.png");
+	pComboBox->clear();
+	pComboBox->addItem(icon, getBankNone());
+
+	int iBankIndex = 0;
+	pBankMap->clear();
+	(*pBankMap)[iBankIndex++] = -1;
+
+	// Care of MIDI plugin instrument banks...
+	bool bMidiManager = updateBanksAdd(icon,
+		m_pMidiImportExtender->pluginListForGui()->midiManager(),
+		sInstrumentName, iBank, iBankIndex,
+		pComboBox, pBankMap);
+
+	// Get instrument set alright...
+	if (!bMidiManager && pInstruments->contains(sInstrumentName)) {
+		// Try to reset old bank
+		pComboBox->setCurrentText(strOldBank);
+		if (pComboBox->currentIndex() > 0)
+			// Old bank found: done
+			return;
+
+		// Instrument reference...
+		const qtractorInstrument& instr
+			= pInstruments->value(sInstrumentName);
+		// For proper bank selection...
+		iBankIndex = -1;
+		if (iBank >= 0) {
+			const qtractorInstrumentData& patch = instr.patch(iBank);
+			if (!patch.name().isEmpty())
+				iBankIndex = pComboBox->findText(patch.name());
+		}
+	}
+	else if (!bMidiManager)
+		iBankIndex = -1;
+
+	// If there's banks we must choose at least one...
+	if (iBank < 0 && pBankMap->count() > 1) {
+		iBankIndex = 1;
+		iBank = (*pBankMap)[iBankIndex];
+	}
+
+	// Do the proper bank selection...
+	if (iBank < 0) {
+		pComboBox->setCurrentIndex(0);
+	} else if (iBankIndex < 0) {
+		pComboBox->setCurrentIndex(0);
+	} else {
+		pComboBox->setCurrentIndex(iBankIndex);
+	}
+}
+
+
+// Update instruments banks.
+bool qtractorMidiImportForm::updateBanksAdd( const QIcon &icon,
+		qtractorMidiManager *pMidiManager,
+		const QString &sInstrumentName,
+		int iBank,
+		int &iBankIndex,
+		QComboBox *pComboBox, QMap<int, int> *pBankMap)
+{
+	if (pMidiManager == NULL)
+		return false;
+
+	// It is possible that bank layout has changed - e.g for fluidsynth-dssi
+	// loaded a new soundfont. So instead of opening and closing dialog, it
+	// is possible to select no instrument and then fluidsyth-dssi to get
+	// proper bank layout.
+	pMidiManager->updateInstruments();
+
+	const qtractorMidiManager::Instruments& list
+		= pMidiManager->instruments();
+	if (!list.contains(sInstrumentName))
+		return false;
+
+	// Refresh bank mapping...
+	const qtractorMidiManager::Banks& banks = list[sInstrumentName];
+	qtractorMidiManager::Banks::ConstIterator iter = banks.constBegin();
+	const qtractorMidiManager::Banks::ConstIterator& iter_end = banks.constEnd();
+	for ( ; iter != iter_end; ++iter) {
+		pComboBox->addItem(icon, iter.value().name);
+		(*pBankMap)[iBankIndex++] = iter.key();
+	}
+	// Reset given bank combobox index.
+	iBankIndex = -1;
+	// For proper bank selection...
+	if (banks.contains(iBank)) {
+		const qtractorMidiManager::Bank& bank = banks[iBank];
+		iBankIndex = pComboBox->findText(bank.name);
+	}
+
+	// Mark that we've have something.
+	return true;
+}
+
+
+// Cleanup right before dialog is closed.
+void qtractorMidiImportForm::commonCleanup()
+{
+	// Close all plugin windows before the turn into zombies.
+	for (qtractorPlugin *pPlugin = m_pMidiImportExtender->pluginListForGui()->first();
+			pPlugin; pPlugin = pPlugin->next()) {
+		pPlugin->closeEditor();
+		pPlugin->closeForm();
+	}
+
+	// Unlink plugin list from view.
+	m_ui.PluginListView->setPluginList(NULL);
+}
+
+
+// end of qtractorMidiImportForm.cpp

--- a/src/qtractorMidiImportForm.h
+++ b/src/qtractorMidiImportForm.h
@@ -1,0 +1,110 @@
+// qtractorMidiImportForm.h
+//
+/****************************************************************************
+   Copyright (C) 2005-2017, rncbc aka Rui Nuno Capela. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#ifndef __qtractorMidiImportForm_h
+#define __qtractorMidiImportForm_h
+
+#include "ui_qtractorMidiImportForm.h"
+
+// forward decalarations.
+class qtractorMidiImportExtender;
+class qtractorCommand;
+class qtractorMidiManager;
+class qtractorTrack;
+class qtractorEditTrackCommand;
+
+
+class qtractorMidiImportForm : public QDialog
+{
+	Q_OBJECT
+
+public:
+
+	// Constructor.
+	qtractorMidiImportForm(qtractorMidiImportExtender *pMidiImportExtender,
+		QWidget *pParent = 0, Qt::WindowFlags wflags = 0);
+	// Destructor.
+	virtual ~qtractorMidiImportForm();
+
+protected slots:
+
+	void accept();
+	void reject();
+
+	void stabilizeListButtons();
+
+	void pluginListChanged();
+	void addPlugin();
+	void removePlugin();
+	void moveUpPlugin();
+	void moveDownPlugin();
+
+	void changedInstInst(const QString &text);
+	void changedDrumInst(const QString &text);
+
+	void changed();
+private:
+
+	// Update instruments comboboxes.
+	void updateInstruments();
+	void updateInstrumentsAdd(
+		const QIcon& icon, qtractorMidiManager *pMidiManager);
+
+	// Update instruments comboboxes.
+	enum BankType { Instruments, Drums };
+	void updateBanks(const QString& sInstrumentName, int iBank, enum BankType bankType);
+	bool updateBanksAdd(
+		const QIcon& icon, qtractorMidiManager *pMidiManager,
+		const QString& sInstrumentName, int iBank, int& iBankIndex,
+			QComboBox* pComboBox, QMap<int, int> *pBankMap);
+
+	// Avoid redundancy for empty texts
+	// FIXME: move to a more common place and share with e.g with track-form
+	const QString getInstrumentNone() { return tr("(No instrument)"); }
+	const QString getBankNone() { return tr("(None)"); }
+
+	// Cleanup right before dialog is closed.
+	void commonCleanup();
+
+	// The Qt-designer UI struct...
+	Ui::qtractorMidiImportForm m_ui;
+
+	// Pointer to object doing the job of MIDI import extension.
+	qtractorMidiImportExtender *m_pMidiImportExtender;
+
+	// Keep last command for backout / restore.
+	qtractorCommand *m_pLastCommand;
+
+	// Button group around name-type radios
+	QButtonGroup* m_groupNameRadios;
+
+	// counter avoiding unwanted handling of change events
+	int m_iDirtySetup;
+
+	// Entry in combobox / bank map for instruments.
+	QMap<int, int> m_instBanks;
+	// Entry in combobox / bank map for drums.
+	QMap<int, int> m_drumBanks;
+};
+
+#endif // __qtractorMidiImportForm_h
+
+// end of qtractorMidiImportForm.h

--- a/src/qtractorMidiImportForm.ui
+++ b/src/qtractorMidiImportForm.ui
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <author>rncbc aka Rui Nuno Capela</author>
+ <comment>qtractor - An Audio/MIDI multi-track sequencer.
+
+   Copyright (C) 2005-2017, rncbc aka Rui Nuno Capela. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ </comment>
+ <class>qtractorMidiImportForm</class>
+ <widget class="QDialog" name="qtractorMidiImportForm">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>0</width>
+    <height>0</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MIDI import</string>
+  </property>
+  <property name="focusPolicy" >
+   <enum>Qt::StrongFocus</enum>
+  </property>
+  <property name="windowIcon" >
+   <iconset resource="qtractor.qrc" >:/images/itemMidiFile.png</iconset>
+  </property>
+  <layout class="QVBoxLayout" >
+   <item>
+    <widget class="QGroupBox" name="Plugins">
+     <property name="title">
+      <string>Plugins</string>
+     </property>
+      <layout class="QHBoxLayout" >
+       <item>
+        <widget class="qtractorPluginListView" name="PluginListView" >
+         <property name="focusPolicy" >
+          <enum>Qt::WheelFocus</enum>
+         </property>
+         <property name="toolTip" >
+          <string>Track plugins</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" >
+         <item>
+          <widget class="QToolButton" name="AddPluginToolButton" >
+           <property name="minimumSize" >
+            <size>
+             <width>90</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="toolTip" >
+            <string>Add plugin</string>
+           </property>
+           <property name="text" >
+            <string>&amp;Add...</string>
+           </property>
+           <property name="icon" >
+            <iconset resource="qtractor.qrc" >:/images/formCreate.png</iconset>
+           </property>
+           <property name="toolButtonStyle" >
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="RemovePluginToolButton" >
+           <property name="minimumSize" >
+            <size>
+             <width>90</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="toolTip" >
+            <string>Remove plugin</string>
+           </property>
+           <property name="text" >
+            <string>&amp;Remove</string>
+           </property>
+           <property name="icon" >
+            <iconset resource="qtractor.qrc" >:/images/formRemove.png</iconset>
+           </property>
+           <property name="toolButtonStyle" >
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation" >
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" >
+            <size>
+             <width>8</width>
+             <height>8</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="MoveUpPluginToolButton" >
+           <property name="minimumSize" >
+            <size>
+             <width>90</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="toolTip" >
+            <string>Move plugin up</string>
+           </property>
+           <property name="text" >
+            <string>&amp;Up</string>
+           </property>
+           <property name="icon" >
+            <iconset resource="qtractor.qrc" >:/images/formMoveUp.png</iconset>
+           </property>
+           <property name="toolButtonStyle" >
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="MoveDownPluginToolButton" >
+           <property name="minimumSize" >
+            <size>
+             <width>90</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="toolTip" >
+            <string>Move plugin down</string>
+           </property>
+           <property name="text" >
+            <string>&amp;Down</string>
+           </property>
+           <property name="icon" >
+            <iconset resource="qtractor.qrc" >:/images/formMoveDown.png</iconset>
+           </property>
+           <property name="toolButtonStyle" >
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" >
+     <property name="spacing" >
+      <number>4</number>
+     </property>
+     <property name="margin" >
+      <number>8</number>
+     </property>
+     <item>
+      <widget class="QGroupBox" name="InstrumentBankGroup">
+       <property name="title">
+        <string>Instrument and bank selection</string>
+       </property>
+       <layout class="QHBoxLayout" >
+        <item>
+         <widget class="QGroupBox" name="InstrumentGroup">
+          <property name="title">
+           <string>Instruments</string>
+          </property>
+          <layout class="QGridLayout" >
+           <property name="margin" >
+            <number>8</number>
+           </property>
+           <property name="spacing" >
+            <number>4</number>
+           </property>
+           <item row="0" column="0" >
+            <widget class="QLabel" name="InstInstTextLabel" >
+             <property name="text" >
+              <string>&amp;Instrument:</string>
+             </property>
+             <property name="buddy" >
+              <cstring>InstInstComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1" colspan="5" >
+            <widget class="QComboBox" name="InstInstComboBox" >
+             <property name="minimumSize" >
+              <size>
+               <width>250</width>
+              </size>
+             </property>            
+             <property name="toolTip" >
+              <string>Select instrument for all instruments</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" >
+            <widget class="QLabel" name="InstBankTextLabel" >
+             <property name="text" >
+              <string>&amp;Bank:</string>
+             </property>
+             <property name="buddy" >
+              <cstring>InstBankComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1" colspan="5" >
+            <widget class="QComboBox" name="InstBankComboBox" >
+             <property name="minimumSize" >
+              <size>
+               <width>250</width>
+              </size>
+             </property>            
+             <property name="toolTip" >
+              <string>Select bank for all instruments</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="DrumGroup">
+          <property name="title">
+           <string>Drums</string>
+          </property>
+          <layout class="QGridLayout" >
+           <property name="margin" >
+            <number>8</number>
+           </property>
+           <property name="spacing" >
+            <number>4</number>
+           </property>
+           <item row="0" column="0" >
+            <widget class="QLabel" name="DrumInstTextLabel" >
+             <property name="text" >
+              <string>&amp;Instrument:</string>
+             </property>
+             <property name="buddy" >
+              <cstring>DrumInstComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1" colspan="5" >
+            <widget class="QComboBox" name="DrumInstComboBox" >
+             <property name="minimumSize" >
+              <size>
+               <width>250</width>
+              </size>
+             </property>            
+             <property name="toolTip" >
+              <string>Select instrument for all drums</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" >
+            <widget class="QLabel" name="DrumBankTextLabel" >
+             <property name="text" >
+              <string>&amp;Bank:</string>
+             </property>
+             <property name="buddy" >
+              <cstring>DrumBankComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1" colspan="5" >
+            <widget class="QComboBox" name="DrumBankComboBox" >
+             <property name="minimumSize" >
+              <size>
+               <width>250</width>
+              </size>
+             </property>            
+             <property name="toolTip" >
+              <string>Select bank for all drums</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="TrackNameGroup">
+     <property name="title">
+      <string>Track names</string>
+     </property>
+     <layout class="QHBoxLayout" >
+      <item>
+       <widget class="QRadioButton" name="NameMidiRadioButton">
+        <property name="toolTip">
+         <string>Set MIDI filename (without extension) for track name</string>
+        </property>
+        <property name="text">
+         <string>&amp;MIDI filename</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="NameTrackRadioButton">
+        <property name="toolTip">
+         <string>Set 'Track n' (n = number) for track name</string>
+        </property>
+        <property name="text">
+         <string>&amp;Track [n]</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="NamePatchRadioButton">
+        <property name="toolTip">
+         <string>Instrument name</string>
+        </property>
+        <property name="text">
+         <string>&amp;Patch name</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>      
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout">
+     <property name="spacing">
+      <number>4</number>
+     </property>
+     <property name="margin">
+      <number>8</number>
+     </property>
+     <item>
+      <widget class="QDialogButtonBox" name="DialogButtonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="4" margin="8" />
+ <customwidgets>
+  <customwidget>
+   <class>qtractorPluginListView</class>
+   <extends>QListWidget</extends>
+   <header>qtractorPluginListView.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>PluginListView</tabstop>
+  <tabstop>AddPluginToolButton</tabstop>
+  <tabstop>RemovePluginToolButton</tabstop>
+  <tabstop>MoveUpPluginToolButton</tabstop>
+  <tabstop>MoveDownPluginToolButton</tabstop>
+  <tabstop>InstInstComboBox</tabstop>
+  <tabstop>InstBankComboBox</tabstop>
+  <tabstop>DrumInstComboBox</tabstop>
+  <tabstop>DrumBankComboBox</tabstop>
+  <tabstop>NameMidiRadioButton</tabstop>
+  <tabstop>DialogButtonBox</tabstop>
+ </tabstops>
+ <resources>
+  <include location="qtractor.qrc" />
+ </resources>
+ <connections/>
+</ui>

--- a/src/qtractorOptions.cpp
+++ b/src/qtractorOptions.cpp
@@ -162,6 +162,13 @@ void qtractorOptions::loadOptions (void)
 	iMidiMmcMode       = m_settings.value("/MmcMode", 3).toInt();
 	iMidiSppMode       = m_settings.value("/SppMode", 3).toInt();
 	iMidiClockMode     = m_settings.value("/ClockMode", 0).toInt();
+	sMidiImportPlugins = m_settings.value("/ImportPlugins").toString();
+	sMidiImportInstInst = m_settings.value("/ImportInstInst").toString();
+	sMidiImportDrumInst = m_settings.value("/ImportDrumInst").toString();
+	iMidiImportInstBank = m_settings.value("/ImportInstBank", -1).toInt();
+	iMidiImportDrumBank = m_settings.value("/ImportDrumBank", -1).toInt();
+	iMidiImportTrackName = m_settings.value("/ImportTrackName", 0).toInt();
+
 	m_settings.endGroup();
 
 	// Metronome options group.
@@ -442,7 +449,7 @@ void qtractorOptions::saveOptions (void)
 	m_settings.setValue("/MetroOffset", uint(iAudioMetroOffset));
 	m_settings.endGroup();
 
-	// MIDI rendering options group.
+	// MIDI rendering and import options group.
 	m_settings.beginGroup("/Midi");
 	m_settings.setValue("/CaptureFormat", iMidiCaptureFormat);
 	m_settings.setValue("/CaptureQuantize", iMidiCaptureQuantize);
@@ -457,6 +464,13 @@ void qtractorOptions::saveOptions (void)
 	m_settings.setValue("/MmcMode", iMidiMmcMode);
 	m_settings.setValue("/SppMode", iMidiSppMode);
 	m_settings.setValue("/ClockMode", iMidiClockMode);
+	m_settings.setValue("/ImportPlugins", sMidiImportPlugins);
+	m_settings.setValue("/ImportInstInst", sMidiImportInstInst);
+	m_settings.setValue("/ImportDrumInst", sMidiImportDrumInst);
+	m_settings.setValue("/ImportInstBank", iMidiImportInstBank);
+	m_settings.setValue("/ImportDrumBank", iMidiImportDrumBank);
+	m_settings.setValue("/ImportTrackName", iMidiImportTrackName);
+
 	m_settings.endGroup();
 
 	// Metronome options group.

--- a/src/qtractorOptions.h
+++ b/src/qtractorOptions.h
@@ -140,6 +140,15 @@ public:
 	int  iMidiSppMode;
 	int  iMidiClockMode;
 
+	// MIDI import options.
+	QString sMidiImportPlugins;
+	QString sMidiImportInstInst;
+	QString sMidiImportDrumInst;
+	int iMidiImportInstBank;
+	int iMidiImportDrumBank;
+	int iMidiImportTrackName;
+
+
 	// MIDI Metronome parameters.
 	int iMetroChannel;
 	int iMetroBarNote;

--- a/src/qtractorOptionsForm.cpp
+++ b/src/qtractorOptionsForm.cpp
@@ -36,6 +36,8 @@
 #include "qtractorMidiMeter.h"
 
 #include "qtractorPluginSelectForm.h"
+#include "qtractorMidiImportForm.h"
+#include "qtractorMidiImportExtender.h"
 
 #include <QFileDialog>
 #include <QFontDialog>
@@ -97,6 +99,9 @@ qtractorOptionsForm::qtractorOptionsForm (
 
 	// Have some deafult time-scale for instance...
 	m_pTimeScale = NULL;
+
+	// Enhanced MIDI import - created on demand
+	m_pMidiImportExtender = NULL;
 
 	qtractorSession *pSession = qtractorSession::getInstance();
 	if (pSession) {
@@ -262,6 +267,9 @@ qtractorOptionsForm::qtractorOptionsForm (
 	QObject::connect(m_ui.MidiCaptureFormatComboBox,
 		SIGNAL(activated(int)),
 		SLOT(changed()));
+	QObject::connect(m_ui.MidiImportPushButton,
+		SIGNAL(clicked()),
+		SLOT(showMidiImportDialog()));
 	QObject::connect(m_ui.MidiCaptureQuantizeComboBox,
 		SIGNAL(activated(int)),
 		SLOT(changed()));
@@ -499,6 +507,7 @@ qtractorOptionsForm::qtractorOptionsForm (
 qtractorOptionsForm::~qtractorOptionsForm (void)
 {
 	if (m_pTimeScale) delete m_pTimeScale;
+	if (m_pMidiImportExtender) delete m_pMidiImportExtender;
 }
 
 
@@ -798,6 +807,9 @@ void qtractorOptionsForm::accept (void)
 		m_pOptions->iMetroBeatDuration   = m_ui.MetroBeatDurationSpinBox->value();
 		m_pOptions->bMidiMetroBus        = m_ui.MidiMetroBusCheckBox->isChecked();
 		m_pOptions->iMidiMetroOffset     = m_ui.MidiMetroOffsetSpinBox->value();
+		// MIDI import options.
+		if (m_pMidiImportExtender)
+			m_pMidiImportExtender->saveSettings();
 		// Display options...
 		m_pOptions->bConfirmRemove       = m_ui.ConfirmRemoveCheckBox->isChecked();
 		m_pOptions->bConfirmArchive      = m_ui.ConfirmArchiveCheckBox->isChecked();
@@ -889,6 +901,10 @@ void qtractorOptionsForm::accept (void)
 	// Save/commit to disk.
 	m_pOptions->saveOptions();
 
+	// Remove plugin list commands from undo menu.
+	if (m_pMidiImportExtender)
+		m_pMidiImportExtender->restoreCommandList();
+
 	// Just go with dialog acceptance
 	QDialog::accept();
 }
@@ -914,6 +930,11 @@ void qtractorOptionsForm::reject (void)
 			accept();
 			return;
 		case QMessageBox::Discard:
+			// In case Midi-Import dialog was closed with OK but changes
+			// shall be discarded, the plugin list's changes must be discarded
+			// too.
+			if (m_pMidiImportExtender)
+				m_pMidiImportExtender->backoutCommandList();
 			break;
 		default:    // Cancel.
 			bReject = false;
@@ -1555,6 +1576,20 @@ void qtractorOptionsForm::chooseSessionTemplatePath (void)
 	m_ui.SessionTemplatePathComboBox->setEditText(sFilename);
 	m_ui.SessionTemplatePathComboBox->setFocus();
 	changed();
+}
+
+
+// Open dialog to change MIDI import settings
+void qtractorOptionsForm::showMidiImportDialog()
+{
+	// First time here: create import extender
+	if (!m_pMidiImportExtender)
+		m_pMidiImportExtender = new qtractorMidiImportExtender();
+	// Show dialog
+	qtractorMidiImportForm midiImportForm(
+				m_pMidiImportExtender, this);
+	if (midiImportForm.exec())
+		changed();
 }
 
 

--- a/src/qtractorOptionsForm.h
+++ b/src/qtractorOptionsForm.h
@@ -28,6 +28,7 @@
 // Forward declarations...
 class qtractorOptions;
 class qtractorTimeScale;
+class qtractorMidiImportExtender;
 
 
 //----------------------------------------------------------------------------
@@ -76,6 +77,7 @@ protected slots:
 	void chooseMessagesFont();
 	void chooseMessagesLogPath();
 	void chooseSessionTemplatePath();
+	void showMidiImportDialog();
 	void stabilizeForm();
 
 protected:
@@ -114,6 +116,9 @@ private:
 	QStringList m_vstPaths;
 
 	int m_iDirtyPluginPaths;
+
+	// Midi import settings handler.
+	qtractorMidiImportExtender *m_pMidiImportExtender;
 };
 
 

--- a/src/qtractorOptionsForm.ui
+++ b/src/qtractorOptionsForm.ui
@@ -1371,7 +1371,7 @@
           </font>
          </property>
          <property name="title">
-          <string>Capture / Export</string>
+          <string>Capture / Export / Import</string>
          </property>
          <property name="flat">
           <bool>true</bool>
@@ -1418,6 +1418,25 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="0" column="4">
+           <widget class="QPushButton" name="MidiImportPushButton">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string>Change defaults for MIDI import</string>
+            </property>
+            <property name="text">
+             <string>&amp;Import Settings...</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="MidiCaptureQuantizeTextLabel">

--- a/src/qtractorPlugin.cpp
+++ b/src/qtractorPlugin.cpp
@@ -1405,7 +1405,8 @@ qtractorPluginList::qtractorPluginList (
 	: m_iChannels(iChannels), m_iFlags(iFlags),
 		m_iActivated(0), m_pMidiManager(NULL),
 		m_iMidiBank(-1), m_iMidiProg(-1),
-		m_pMidiProgramSubject(NULL), m_bAutoDeactivated(false)
+		m_pMidiProgramSubject(NULL), m_bAutoDeactivated(false),
+		m_iForceNoProcessing(0)
 {
 	setAutoDelete(true);
 
@@ -1796,6 +1797,10 @@ void qtractorPluginList::removeView ( qtractorPluginListView *pView )
 // The meta-main audio-processing plugin-chain procedure.
 void qtractorPluginList::process ( float **ppBuffer, unsigned int nframes )
 {
+	// Forced not to process data?
+	if (m_iForceNoProcessing)
+		return;
+
 	// Sanity checks...
 	if (!isActivated())
 		return;
@@ -2213,6 +2218,14 @@ void qtractorPluginList::autoDeactivatePlugins ( bool bDeactivated, bool bForce 
 bool qtractorPluginList::isAutoDeactivated (void) const
 {
 	return m_bAutoDeactivated;
+}
+
+void qtractorPluginList::forceNoProcessing(bool bForce)
+{
+	if (bForce)
+		++m_iForceNoProcessing;
+	else if (m_iForceNoProcessing > 0)
+		--m_iForceNoProcessing;
 }
 
 

--- a/src/qtractorPlugin.h
+++ b/src/qtractorPlugin.h
@@ -928,6 +928,9 @@ public:
 	void autoDeactivatePlugins(bool bDeactivated, bool bForce = false);
 	bool isAutoDeactivated() const;
 
+	// Force no sound processing.
+	void forceNoProcessing(bool bForce);
+
 protected:
 
 	// Check/sanitize plugin file-path.
@@ -978,6 +981,9 @@ private:
 
 	// Auto-plugin-deactivation
 	bool m_bAutoDeactivated;
+
+	// Force no sound processing.
+	int m_iForceNoProcessing;
 };
 
 

--- a/src/qtractorPluginListDocument.cpp
+++ b/src/qtractorPluginListDocument.cpp
@@ -1,0 +1,54 @@
+// qtractorPluginListDocument.cpp
+//
+/****************************************************************************
+   Copyright (C) 2005-2017, rncbc aka Rui Nuno Capela. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#include "qtractorPluginListDocument.h"
+#include "qtractorPlugin.h"
+
+
+// Constructor.
+qtractorPluginListDocument::qtractorPluginListDocument(
+		QDomDocument *pDocument, qtractorPluginList *pPluginList)
+		: qtractorDocument(pDocument, "qtractorPluginList"),
+		m_pPluginList(pPluginList)
+
+{
+
+}
+
+
+// Destructor.
+qtractorPluginListDocument::~qtractorPluginListDocument()
+{
+}
+
+
+bool qtractorPluginListDocument::loadElement(QDomElement *pElement)
+{
+	return m_pPluginList->loadElement(this, pElement);
+}
+
+
+bool qtractorPluginListDocument::saveElement(QDomElement *pElement)
+{
+	return m_pPluginList->saveElement(this, pElement);
+}
+
+// end of qtractorPluginListDocument.cpp

--- a/src/qtractorPluginListDocument.h
+++ b/src/qtractorPluginListDocument.h
@@ -1,0 +1,49 @@
+// qtractorPluginListDocument.h
+//
+/****************************************************************************
+   Copyright (C) 2005-2017, rncbc aka Rui Nuno Capela. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#ifndef __qtractorPluginListDocument_h
+#define __qtractorPluginListDocument_h
+
+#include "qtractorDocument.h"
+
+// Forward declarations.
+class qtractorPluginList;
+
+class qtractorPluginListDocument : public qtractorDocument
+{
+public:
+
+	// Constructor.
+	qtractorPluginListDocument(QDomDocument *pDocument, qtractorPluginList *pPluginList);
+	// Destructor.
+	~qtractorPluginListDocument();
+
+	// External storage element overrides.
+	virtual bool loadElement (QDomElement *pElement);
+	virtual bool saveElement (QDomElement *pElement);
+
+private:
+	qtractorPluginList *m_pPluginList;
+};
+
+#endif // __qtractorPluginListDocument_h
+
+// end of qtractorPluginListDocument.h

--- a/src/qtractorSession.cpp
+++ b/src/qtractorSession.cpp
@@ -33,6 +33,7 @@
 #include "qtractorMidiEngine.h"
 #include "qtractorMidiClip.h"
 #include "qtractorMidiManager.h"
+#include "qtractorMidiImportExtender.h"
 
 #include "qtractorPlugin.h"
 #include "qtractorCurve.h"
@@ -262,6 +263,7 @@ void qtractorSession::clear (void)
 
 	qtractorAudioClip::clearHashTable();
 	qtractorMidiClip::clearHashTable();
+	qtractorMidiImportExtender::clearPluginList();
 
 	m_iSessionStart  = 0;
 	m_iSessionEnd    = 0;

--- a/src/qtractorTrackList.cpp
+++ b/src/qtractorTrackList.cpp
@@ -46,6 +46,7 @@
 #include "qtractorMidiMonitor.h"
 #include "qtractorAudioMeter.h"
 #include "qtractorMidiMeter.h"
+#include "qtractorMidiImportExtender.h"
 
 #include "qtractorOptions.h"
 
@@ -1596,8 +1597,11 @@ void qtractorTrackList::dropEvent ( QDropEvent *pDropEvent )
 	const unsigned long iClipStart = (pSession ? pSession->editHead() : 0);
 	qtractorTrack *pAfterTrack = currentTrack();
 
-	if (!midi_files.isEmpty())
-		m_pTracks->addMidiTracks(midi_files, iClipStart, pAfterTrack);
+	if (!midi_files.isEmpty()) {
+		qtractorMidiImportExtender midiImportExtenter;
+		m_pTracks->addMidiTracks(
+					midi_files, iClipStart, pAfterTrack, &midiImportExtenter);
+	}
 	if (!audio_files.isEmpty())
 		m_pTracks->addAudioTracks(audio_files, iClipStart, pAfterTrack);
 

--- a/src/qtractorTracks.cpp
+++ b/src/qtractorTracks.cpp
@@ -61,8 +61,11 @@
 
 #include "qtractorMidiToolsForm.h"
 #include "qtractorMidiEditSelect.h"
+#include "qtractorMidiImportExtender.h"
 
 #include "qtractorFileList.h"
+
+#include "qtractorMixer.h"
 
 #include <QVBoxLayout>
 #include <QProgressBar>
@@ -2802,8 +2805,9 @@ bool qtractorTracks::addAudioTracks ( const QStringList& files,
 
 
 // Import MIDI files into new tracks...
-bool qtractorTracks::addMidiTracks ( const QStringList& files,
-	unsigned long iClipStart, qtractorTrack *pAfterTrack )
+bool qtractorTracks::addMidiTracks (const QStringList& files,
+	unsigned long iClipStart, qtractorTrack *pAfterTrack,
+	qtractorMidiImportExtender *pMidiImportExtender)
 {
 	// Have we some?
 	if (files.isEmpty())
@@ -2813,10 +2817,13 @@ bool qtractorTracks::addMidiTracks ( const QStringList& files,
 	if (pSession == NULL)
 		return false;
 
+	// Tell the world we'll take some time...
+	QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+
 //	pSession->lock();
 
-	// Account for actual updates...
-	int iUpdate = 0;
+	// Collect tracks added.
+	QList<qtractorTrack *> addedTracks;
 
 	// We'll build a composite command...
 	qtractorImportTrackCommand *pImportTrackCommand
@@ -2877,12 +2884,14 @@ bool qtractorTracks::addMidiTracks ( const QStringList& files,
 			}
 			// Time to check whether there is actual data on track...
 			if (pMidiClip->clipLength() > 0) {
+				addedTracks.append(pTrack);
 				// Add the new track to composite command...
 				pTrack->setTrackName(
 					pSession->uniqueTrackName(pMidiClip->clipName()));
 				pTrack->setMidiChannel(pMidiClip->channel());
+				if (pMidiImportExtender)
+					pMidiImportExtender->prepareTrackForExtension(pTrack);
 				pImportTrackCommand->addTrack(pTrack);
-				++iUpdate;
 				// Don't forget to add this one to local repository.
 				if (pMainForm)
 					pMainForm->addMidiFile(sPath);
@@ -2894,7 +2903,7 @@ bool qtractorTracks::addMidiTracks ( const QStringList& files,
 			}
 		}
 		// Log this successful import operation...
-		if (iUpdate > 0 && pMainForm) {
+		if (addedTracks.count() && pMainForm) {
 			sDescription += tr("MIDI file import \"%1\" on %2 %3.\n")
 				.arg(QFileInfo(sPath).fileName())
 				.arg(QDate::currentDate().toString("MMM dd yyyy"))
@@ -2906,16 +2915,28 @@ bool qtractorTracks::addMidiTracks ( const QStringList& files,
 
 	// Have we changed anything?
 	bool bResult = false;
-	if (iUpdate > 0) {
+	if (addedTracks.count()) {
 		// Log to session (undoable by import-track command)...
 		pSession->setDescription(sDescription);	
 		// Put it in the form of an undoable command...
 		bResult = pSession->execute(pImportTrackCommand);
+		// Tracks are complete now: instrument and track-name (based on
+		// patch name are depending on instrument) can be set.
+		if (bResult &&
+				pMidiImportExtender &&
+				pMidiImportExtender->finishTracksForExtension(&addedTracks)) {
+			// Mixer needs extra invitation...
+			qtractorMixer *pMixer = pMainForm->mixer();
+			if (pMixer)
+				pMixer->updateTracks(true);
+		}
 	} else {
 		delete pImportTrackCommand;
 	}
 
 //	pSession->unlock();
+
+	QApplication::restoreOverrideCursor();
 
 	return bResult;
 }

--- a/src/qtractorTracks.h
+++ b/src/qtractorTracks.h
@@ -35,6 +35,7 @@ class qtractorClipRangeCommand;
 class qtractorClipToolCommand;
 
 class qtractorMidiToolsForm;
+class qtractorMidiImportExtender;
 
 
 //----------------------------------------------------------------------------
@@ -71,7 +72,8 @@ public:
 	bool addAudioTracks(const QStringList& files,
 		unsigned long iClipStart, qtractorTrack *pAfterTrack = NULL);
 	bool addMidiTracks(const QStringList& files,
-		unsigned long iClipStart, qtractorTrack *pAfterTrack = NULL);
+		unsigned long iClipStart, qtractorTrack *pAfterTrack = NULL,
+		qtractorMidiImportExtender *pMidiImportExtender = NULL);
 	bool addMidiTrackChannel(const QString& sPath, int iTrackChannel,
 		unsigned long iClipStart, qtractorTrack *pAfterTrack = NULL);
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -46,6 +46,8 @@ HEADERS += config.h \
 	qtractorFileListView.h \
 	qtractorFiles.h \
 	qtractorFileSystem.h \
+	qtractorMidiImportExtender.h \
+	qtractorMidiImportForm.h \
 	qtractorInsertPlugin.h \
 	qtractorInstrument.h \
 	qtractorInstrumentMenu.h \
@@ -204,6 +206,8 @@ SOURCES += \
 	qtractorMidiEventList.cpp \
 	qtractorMidiFile.cpp \
 	qtractorMidiFileTempo.cpp \
+	qtractorMidiImportExtender.cpp \
+	qtractorMidiImportForm.cpp \
 	qtractorMidiListView.cpp \
 	qtractorMidiManager.cpp \
 	qtractorMidiMeter.cpp \
@@ -278,6 +282,7 @@ FORMS += \
 	qtractorMidiControlForm.ui \
 	qtractorMidiControlObserverForm.ui \
 	qtractorMidiEditorForm.ui \
+	qtractorMidiImportForm.ui \
 	qtractorMidiSysexForm.ui \
 	qtractorMidiToolsForm.ui \
 	qtractorOptionsForm.ui \

--- a/src/src.pro
+++ b/src/src.pro
@@ -95,6 +95,7 @@ HEADERS += config.h \
 	qtractorPlugin.h \
 	qtractorPluginFactory.h \
 	qtractorPluginCommand.h \
+	qtractorPluginListDocument.h \
 	qtractorPluginListView.h \
 	qtractorPropertyCommand.h \
 	qtractorRingBuffer.h \
@@ -220,6 +221,7 @@ SOURCES += \
 	qtractorPlugin.cpp \
 	qtractorPluginFactory.cpp \
 	qtractorPluginCommand.cpp \
+	qtractorPluginListDocument.cpp \
 	qtractorPluginListView.cpp \
 	qtractorRubberBand.cpp \
 	qtractorScrollView.cpp \


### PR DESCRIPTION
This is more a request for comments than a pull request. Please take some time because I think it is worth: I have MIDI import at daily use and this extension. It makes things lot easier (e.g adding some drum loop: it plays immediately in a given session and makes decision keep/try next less painful)

**Some implementation details:**
The main functionality happens in new class qtractorMidiImportExtender. During Midi-Import there are two methods used:
**prepareTrackForExtension**: The plugins are added here and the whole list stops processing. This is called for 'bare' tracks (before they are added to session). There were many variants tested: The only place that plugins can be added is at this early stage. Adding plugins later did not work properly e.g fluidsynth based plugins did not load their soundfonts properly.
**finishTracksForExtension**: Make plugin list process again / set Midi Bank / set track name

When I implemented this, I tried to keep API changes as few as possible but there had to be some:
* Add class qtractorPluginListDocument: This was necessary to get a whole plugin-list into a QDomDocument. Advantage of this solution is that all infrastructure for saving/loading session could be reused.
* Add qtractorPluginList::forceNoProcessing: Force a whole plugin-list to skip processing. Deactivating plugins one by one did not work because the plugins use deactivate/activate e.g in qtractorLadspaPlugin::setChannels.

**Known issues:**
* When opening Plugin's windows from qtractorMidiImportForm the are forced to background - I would be glad for any suggestions
* For VST plugins the patches are not properly set - will investigate further.