### PR TITLE
Make toggle shortcuts work in both latching and non-latching way

### DIFF
--- a/src/qtractorActionControl.cpp
+++ b/src/qtractorActionControl.cpp
@@ -40,7 +40,10 @@ qtractorActionControl::MidiObserver::MidiObserver ( QAction *pAction )
 
 	qtractorMidiControlObserver::setSubject(&m_subject);
 	qtractorMidiControlObserver::setHook(true);
-	qtractorMidiControlObserver::setLatch(true);
+	// Enable Latch by default for toggled actions
+	if (m_subject.isToggled()) {
+		qtractorMidiControlObserver::setLatch(true);
+	}
 }
 
 

--- a/src/qtractorMidiControlObserverForm.cpp
+++ b/src/qtractorMidiControlObserverForm.cpp
@@ -209,8 +209,8 @@ void qtractorMidiControlObserverForm::setMidiObserver (
 	m_ui.HookCheckBox->setChecked(m_pMidiObserver->isHook() && bDecimal);
 	m_ui.HookCheckBox->setEnabled(bDecimal);
 
-	m_ui.LatchCheckBox->setChecked(m_pMidiObserver->isLatch() && bToggled);
-	m_ui.LatchCheckBox->setEnabled(bToggled && !m_pMidiObserver->isInteger());
+	m_ui.LatchCheckBox->setChecked(m_pMidiObserver->isLatch());
+	m_ui.LatchCheckBox->setEnabled(bToggled);
 
 	qtractorMidiControl *pMidiControl
 		= qtractorMidiControl::getInstance();


### PR DESCRIPTION
Fixes #108 

Checked the following locally:
- Toggleable shortcuts like "Mute current Track" work with latching controllers when "Latch" is enabled
- Toggleable shortcuts like "Mute current Track" work with non-latching/momentary controllers when "Latch" is disabled
- One-shot shortcuts like "Next Track" work with any value (0-127) and the "Latch" checkbox is greyed out
- I don't think there are any other shortcuts types to check?
- MIDI mappings made via "Controllers" work
- "Global" MIDI mappings like CC7/volume work

> the "Latch" setting is "true" on MidiControlObserver::ctor because it is the usual mode on most MIDI controller devices that I know of; the non-latch/momentary ones seem to be rare out there, but that's not a real issue or is it?

I changed this so it now defaults to `Latch=True` for Toggleable actions.

> "one-shot" shortcuts (ActionControl::MidiObserver) in fact were just being flagged as such by having both "Integer" and "Latch" attributes set to "true";

Correct, that's not the case anymore, the `qtractorMidiControlObserver`'s `Latch` variable shouldn't be relevant for oneshot actions.
Though I'm not 100% happy with what I have now. IMHO it would be better if actions had a bool that identifies them as "oneshot" and based on that `qtractorSubject::setValue` should do the right thing. I.e. always trigger for oneshot irrespective of the value and otherwise just apply the value.
That way there's a clear separation between the MIDI handling (in `qtractorMidiControlObserver`) and the logic related to the action/`qtractorSubject`.

> your proposed commit seem to overrule both of the above, and makes me think whether it's neutral to other modes of controllers but plain ""one-shot" and toggled" ones.
note also that I've done no field-tests, i'm just guessing

I've tested everything I could think of (see list above), but I could've missed something.
Note I have very little C/C++ experience, so please do check properly ;)