### PR TITLE
qtractorSession::canTrackBeAutoDeactivated: deactivate more when playing

### DIFF
--- a/src/qtractorSession.cpp
+++ b/src/qtractorSession.cpp
@@ -1820,17 +1820,23 @@ bool qtractorSession::canTrackBeAutoDeactivated ( qtractorTrack *pTrack ) const
 	if (pCurveList)
 		bAutomationActive = pCurveList->isProcess() || pCurveList->isCapture();
 
-	// No Auto-plugin-deactivation active automation
+	// No Auto-plugin-deactivation when automation active
 	// Note: freewheeling case is done the hard way by disabling
 	// auto-deactivate as whole - see qtractorMainForm::trackExportAudio
 	if (!bAutomationActive) {
 		if (isPlaying()) {
-			// TBD: We know when clips start/end. So if 'just' need a
-			// clever song pos synced call of autoPluginsDeactivate
-			bool bMute = pTrack->isMute();
-			if(!bMute)
-				bMute = m_iSoloTracks > 0 && !pTrack->isSolo();
-			bCanBeDeactivated = !isTrackMonitor(pTrack) && bMute;
+			// Monitored and recording tracks cannot be deactivated
+			if(!isTrackMonitor(pTrack) && !pTrack->isRecord()) {
+				bool bMute = pTrack->isMute();
+				if(!bMute)
+					bMute = m_iSoloTracks > 0 && !pTrack->isSolo();
+				// TBD: We know when clips start/end. So we 'just' need a
+				// clever song pos synced call of autoPluginsDeactivate
+				// For now only check if track contains clips.
+				bool bHasClips = pTrack->clips().count() > 0;
+				if (bMute || !bHasClips)
+					bCanBeDeactivated = true;
+			}
 		} else {
 			bCanBeDeactivated = !isTrackMonitor(pTrack);
 		}

--- a/src/qtractorTrack.cpp
+++ b/src/qtractorTrack.cpp
@@ -765,6 +765,8 @@ void qtractorTrack::setRecord ( bool bRecord )
 
 	m_pRecordSubject->setValue(bRecord ? 1.0f : 0.0f);
 
+	m_pSession->autoDeactivatePlugins();
+
 	if (m_pSession->isRecording()) {
 		unsigned long iClipStart = m_pSession->playHead();
 		if (m_pSession->isPunching()) {


### PR DESCRIPTION
Currently when playing with e.g.

1. few tracks with clips e.g drum & base
2. some tracks preset to favorite instruments but only making sound when
   set current (-> monitor).

only those tracks in 2. which are muted (often none) are deactivated. With loop
active, this is my typical setup for jamming.

With this patch also those are deactivated which do not have clips or do not
record new clips.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>