### PR TITLE
Fix broken mixer after track edit

### DIFF
--- a/src/qtractorTrackCommand.cpp
+++ b/src/qtractorTrackCommand.cpp
@@ -785,6 +785,11 @@ bool qtractorEditTrackCommand::redo (void)
 			pClip->open();
 	}
 
+	// Mixer turn...
+	qtractorMixer *pMixer = pMainForm->mixer();
+	if (pMixer)
+		pMixer->updateTracks(true);
+
 	// Finally update any outstanding clip editors...
 	m_pTrack->updateClipEditors();
 


### PR DESCRIPTION
To reproduce the bug:
* Open very simple session [test.zip](https://github.com/rncbc/qtractor/files/1587901/test.zip)
* Open mixer window
* Change volume -> Volume changes as expected
* Edit track - e.g rename it and leave track edit dialog with OK
* Change volume again -> nothing happens: Even mixer's text-field 'Volume %' does not change
 
Have no idea when this came in and if the patch is a proper fix but after applying the the bug is gone.