### PR TITLE
Send correct sub-ID 0x07 for MMC Responses

### DIFF
--- a/src/qtractorMidiEngine.cpp
+++ b/src/qtractorMidiEngine.cpp
@@ -2916,7 +2916,7 @@ void qtractorMidiEngine::sendMmcCommand (
 	pSysex[iSysex++] = 0xf0;				// Sysex header.
 	pSysex[iSysex++] = 0x7f;				// Realtime sysex.
 	pSysex[iSysex++] = m_mmcDevice;			// MMC device id.
-	pSysex[iSysex++] = 0x06;				// MMC command mode.
+	pSysex[iSysex++] = 0x07;				// MMC Response.
 	pSysex[iSysex++] = (unsigned char) cmd;	// MMC command code.
 	if (pMmcData && iMmcData > 0) {
 		pSysex[iSysex++] = iMmcData;


### PR DESCRIPTION
Small change to fix the MCC sub-ID for responses. It used to be `0x06` which is for commands coming from the controller.
Changed it to `0x07` which is for responses.

From the [MIDI specs](https://www.midi.org/downloads?task=callelement&format=raw&item_id=92&element=f85c494b-2b32-4109-b8c1-083cca2b7db6&method=download), page 202 (page 1 from the MMC docs).
> MIDI Machine Control uses two Universal Real Time System Exclusive ID numbers (sub-ID's), one for Commands (transmissions from Controller to Controlled Device) and one for Responses (transmissions from Controlled Device to Controller).
> Throughout this document "mcc" and "mcr" will be used to denote the Machine Control Command and Machine Controle Response sub-ID's respectively.
> ...
> Actual values for <mcc> and <mcr> are 06hex and 07hex respectively.
