### PR TITLE
Add MMC Track input monitor support

### DIFF
--- a/src/qtractorMainForm.cpp
+++ b/src/qtractorMainForm.cpp
@@ -5981,6 +5981,9 @@ void qtractorMainForm::setTrack ( int scmd, int iTrack, bool bOn )
 			case qtractorMmcEvent::TRACK_SOLO:
 				pTrack->setSolo(bOn);
 				break;
+			case qtractorMmcEvent::TRACK_INPUT_MONITOR:
+				pTrack->setMonitor(bOn);
+				break;
 			default:
 				break;
 			}

--- a/src/qtractorMmcEvent.h
+++ b/src/qtractorMmcEvent.h
@@ -80,6 +80,7 @@ public:
 	enum SubCommand {
 		TRACK_NONE              = 0x00,
 		TRACK_RECORD            = 0x4f,
+		TRACK_INPUT_MONITOR     = 0x53,
 		TRACK_MUTE              = 0x62,
 		TRACK_SOLO              = 0x66 // Custom-implementation ;)
 	};


### PR DESCRIPTION
Add support for MCC Track input monitor support :)
[According to the docs](https://sourceforge.net/p/qtractor/wiki/Manual%20-%204%20Qtractor--An%20Overview/#41-routing-connections-ports-tracks-and-buses) the "Monitor" toggle is for input monitoring, so it should be the correct hex.