### PR TITLE
Auto-deactivate: Add initial call after loading session

### DIFF
--- a/src/qtractorMainForm.cpp
+++ b/src/qtractorMainForm.cpp
@@ -2520,6 +2520,13 @@ bool qtractorMainForm::loadSessionFileEx (
 	// Now we'll try to create (update) the whole GUI session.
 	updateSessionPost();
 
+	// Do initial auto-deactivate as late as possible to give tracks/plugins
+	// the chance to perform initial program-change events
+	if (m_pSession->isAutoDeactivate()) {
+		m_pSession->stabilize();
+		m_pSession->autoDeactivatePlugins();
+	}
+
 	return bLoadSessionFileEx;
 }
 


### PR DESCRIPTION
Avoid flood of red messages when opening many-track sessions on weak machines.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>