### PR TITLE
A prototype implementation of "tempo-tracks".

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -99,6 +99,9 @@ headers = \
 	src/qtractorSessionCursor.h \
 	src/qtractorSessionDocument.h \
 	src/qtractorSpinBox.h \
+	src/qtractorTempoCurve.h \
+	src/qtractorTempoCurveCommand.h \
+	src/qtractorTempoCurveSelect.h \
 	src/qtractorThumbView.h \
 	src/qtractorTimeScale.h \
 	src/qtractorTimeScaleCommand.h \
@@ -221,6 +224,9 @@ sources = \
 	src/qtractorSessionCursor.cpp \
 	src/qtractorSessionDocument.cpp \
 	src/qtractorSpinBox.cpp \
+	src/qtractorTempoCurve.cpp \
+	src/qtractorTempoCurveCommand.cpp \
+	src/qtractorTempoCurveSelect.cpp \
 	src/qtractorThumbView.cpp \
 	src/qtractorTimeScale.cpp \
 	src/qtractorTimeScaleCommand.cpp \

--- a/src/qtractorAudioEngine.cpp
+++ b/src/qtractorAudioEngine.cpp
@@ -997,7 +997,7 @@ int qtractorAudioEngine::process ( unsigned int nframes )
 		for (qtractorTrack *pTrack = pSession->tracks().first();
 				pTrack; pTrack = pTrack->next()) {
 			// Audio-buffers needs some preparation...
-			if (pTrack->trackType() == qtractorTrack::Audio) {
+			if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Tempo)) {
 				qtractorAudioBus *pInputBus
 					= static_cast<qtractorAudioBus *> (pTrack->inputBus());
 				qtractorAudioMonitor *pAudioMonitor
@@ -2194,7 +2194,7 @@ void qtractorAudioEngine::resetAllMonitors (void)
 	// Reset all audio track channel monitors...
 	for (qtractorTrack *pTrack = pSession->tracks().first();
 			pTrack; pTrack = pTrack->next()) {
-		if (pTrack->trackType() == qtractorTrack::Audio) {
+		if ((pTrack->trackType() == qtractorTrack::Audio) ||(pTrack->trackType() == qtractorTrack::Tempo)) {
 			qtractorAudioMonitor *pAudioMonitor
 				= static_cast<qtractorAudioMonitor *> (pTrack->monitor());
 			if (pAudioMonitor)

--- a/src/qtractorClip.cpp
+++ b/src/qtractorClip.cpp
@@ -309,11 +309,9 @@ void qtractorClip::updateClipTime (void)
 	if (pSession == NULL)
 		return;
 
-	m_iClipStart = pSession->frameFromTick(m_iClipStartTime);
-	m_iClipLength = pSession->frameFromTickRange(
-		m_iClipStartTime, m_iClipStartTime + m_iClipLengthTime);
-	m_iClipOffset = pSession->frameFromTickRange(
-		m_iClipStartTime, m_iClipStartTime + m_iClipOffsetTime, true);
+	setClipStart(m_iClipStart);
+	setClipLength(m_iClipLength);
+	setClipOffset(m_iClipOffset);
 
 	m_iFadeInLength = pSession->frameFromTickRange(
 		m_iClipStartTime, m_iClipStartTime + m_iFadeInTime);

--- a/src/qtractorClipCommand.cpp
+++ b/src/qtractorClipCommand.cpp
@@ -99,7 +99,7 @@ void qtractorClipCommand::fileClip ( qtractorClip *pClip,
 	pItem->trackChannel = iTrackChannel;
 	m_items.append(pItem);
 
-	reopenClip(pClip, (pClip->track())->trackType() == qtractorTrack::Audio);
+	reopenClip(pClip, (((pClip->track())->trackType() == qtractorTrack::Audio) || ((pClip->track())->trackType() == qtractorTrack::Tempo)));
 }
 
 
@@ -214,6 +214,7 @@ void qtractorClipCommand::resizeClip ( qtractorClip *pClip,
 	if (fTimeStretch > 0.0f) {
 		pItem->timeStretch = fTimeStretch;
 		switch ((pClip->track())->trackType()) {
+		case qtractorTrack::Tempo:
 		case qtractorTrack::Audio: {
 			qtractorAudioClip *pAudioClip
 				= static_cast<qtractorAudioClip *> (pClip);
@@ -418,7 +419,7 @@ bool qtractorClipCommand::addClipRecord (
 
 	unsigned long iClipOffset = pClip->clipOffset();
 	// Audio clips may need some record latency compensation...
-	if (trackType == qtractorTrack::Audio) {
+	if ((trackType == qtractorTrack::Audio) || (trackType == qtractorTrack::Tempo)) {
 		qtractorAudioBus *pAudioBus
 			= static_cast<qtractorAudioBus *> (pTrack->inputBus());
 		if (pAudioBus)
@@ -486,6 +487,7 @@ bool qtractorClipCommand::addClipRecordTake ( qtractorTrack *pTrack,
 	qtractorMainForm *pMainForm = qtractorMainForm::getInstance();
 
 	switch (pTrack->trackType()) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio: {
 		qtractorAudioClip *pAudioClip
 			= static_cast<qtractorAudioClip *> (pClip);
@@ -703,7 +705,7 @@ bool qtractorClipCommand::execute ( bool bRedo )
 			float fOldTimeStretch = 0.0f;
 			float fOldPitchShift  = 0.0f;
 			qtractorAudioClip *pAudioClip = NULL;
-			if (pTrack->trackType() == qtractorTrack::Audio) {
+			if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Tempo)) {
 				pAudioClip = static_cast<qtractorAudioClip *> (pClip);
 				if (pAudioClip) {
 					if (pItem->timeStretch > 0.0f) {
@@ -779,7 +781,7 @@ bool qtractorClipCommand::execute ( bool bRedo )
 		}
 		case TimeStretchClip: {
 			qtractorAudioClip *pAudioClip = NULL;
-			if (pTrack->trackType() == qtractorTrack::Audio)
+			if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Tempo))
 				pAudioClip = static_cast<qtractorAudioClip *> (pClip);
 			if (pAudioClip) {
 				const float fOldTimeStretch = pAudioClip->timeStretch();
@@ -791,7 +793,7 @@ bool qtractorClipCommand::execute ( bool bRedo )
 		}
 		case PitchShiftClip: {
 			qtractorAudioClip *pAudioClip = NULL;
-			if (pTrack->trackType() == qtractorTrack::Audio)
+			if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Audio))
 				pAudioClip = static_cast<qtractorAudioClip *> (pClip);
 			if (pAudioClip) {
 				const float fOldPitchShift = pAudioClip->pitchShift();
@@ -824,7 +826,7 @@ bool qtractorClipCommand::execute ( bool bRedo )
 		}
 		case WsolaClip: {
 			qtractorAudioClip *pAudioClip = NULL;
-			if (pTrack->trackType() == qtractorTrack::Audio)
+			if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Audio))
 				pAudioClip = static_cast<qtractorAudioClip *> (pClip);
 			if (pAudioClip) {
 				const bool bOldWsolaTimeStretch = pAudioClip->isWsolaTimeStretch();

--- a/src/qtractorClipForm.cpp
+++ b/src/qtractorClipForm.cpp
@@ -270,6 +270,7 @@ void qtractorClipForm::setClip ( qtractorClip *pClip, bool bClipNew )
 	// Now those things specific on track type...
 	const QString sSuffix = m_ui.FilenameComboBox->objectName();
 	switch (trackType()) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio: {
 		m_ui.FilenameComboBox->setObjectName("Audio" + sSuffix);
 		m_ui.ClipGainTextLabel->setText(tr("&Gain:"));
@@ -677,6 +678,7 @@ void qtractorClipForm::browseFilename (void)
 
 	qtractorTrack::TrackType clipType = trackType();
 	switch (clipType) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		sType = tr("Audio");
 		sExt = qtractorAudioFileFactory::defaultExt();
@@ -793,6 +795,7 @@ void qtractorClipForm::fileChanged (
 		}
 		break;
 	}
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio: {
 		qtractorAudioFile *pFile
 			= qtractorAudioFileFactory::createAudioFile(sFilename);

--- a/src/qtractorMainForm.cpp
+++ b/src/qtractorMainForm.cpp
@@ -78,6 +78,7 @@
 
 #include "qtractorTrackCommand.h"
 #include "qtractorCurveCommand.h"
+#include "qtractorTempoCurveCommand.h"
 
 #include "qtractorMessageList.h"
 
@@ -896,6 +897,9 @@ qtractorMainForm::qtractorMainForm (
 	QObject::connect(m_ui.trackExportMidiAction,
 		SIGNAL(triggered(bool)),
 		SLOT(trackExportMidi()));
+	QObject::connect(m_ui.trackTempoCurveShowAction,
+		SIGNAL(triggered(bool)),
+		SLOT(trackTempoCurveShow()));
 	QObject::connect(m_ui.trackCurveSelectMenu,
 		SIGNAL(triggered(QAction *)),
 		SLOT(trackCurveSelect(QAction *)));
@@ -2483,6 +2487,8 @@ bool qtractorMainForm::loadSessionFileEx (
 			updateRecentFiles(sFilename);
 		//	m_iDirtyCount = 0;
 		}
+		if (bUpdate)
+			m_iDirtyCount = 0;
 		// Save as default session directory...
 		if (m_pOptions && bUpdate) {
 			// Do not set (next) default session directory on zip/archives...
@@ -3885,6 +3891,38 @@ void qtractorMainForm::trackExportMidi (void)
 	qtractorExportForm exportForm(this);
 	exportForm.setExportType(qtractorTrack::Midi);
 	exportForm.exec();
+}
+
+void qtractorMainForm::trackTempoCurveShow(void)
+{
+	qtractorSubject *pSubject = NULL;
+//	qtractorCurveList *pCurveList = NULL;
+	qtractorMidiControlObserver *pMidiObserver;
+	qtractorTrack *pTrack = NULL;
+	if (m_pTracks)
+		pTrack = m_pTracks->currentTrack();
+
+	pMidiObserver = pTrack->tempoObserver();
+	if (pMidiObserver) {
+		pSubject = pMidiObserver->subject();
+	}
+
+	qtractorTempoCurve *pTempoCurve = NULL;
+	if (pSubject) {
+		pTempoCurve = pSubject->tempoCurve();
+
+		if (pTempoCurve == NULL) {
+			pTempoCurve = new qtractorTempoCurve(m_pSession->timeScale(), pSubject);
+		}
+		pTrack->setTrackTempoCurve(pTempoCurve);
+		pTrack->setCurrentCurve(NULL);
+
+		m_pSession->execute(new qtractorTempoCurveEditCommand(pTempoCurve));
+	}
+
+#ifdef CONFIG_DEBUG
+	qDebug("qtractorMainForm::trackTempoCurveShow(%p)", pTempoCurve);
+#endif
 }
 
 
@@ -6519,6 +6557,7 @@ void qtractorMainForm::updateExportMenu (void)
 				pTrack; pTrack = pTrack->next()) {
 			const int iClips = pTrack->clips().count();
 			switch (pTrack->trackType()) {
+			case qtractorTrack::Tempo:
 			case qtractorTrack::Audio:
 				iAudioClips += iClips;
 				break;
@@ -6906,6 +6945,10 @@ void qtractorMainForm::updateCurveMenu (void)
 	qtractorCurve *pCurrentCurve
 		= (pCurveList ? pCurveList->currentCurve() : NULL);
 
+	if (pTrack->trackType() == qtractorTrack::Tempo) {
+		m_ui.trackTempoCurveShowAction->setEnabled(true);
+	} else
+		m_ui.trackTempoCurveShowAction->setEnabled(false);
 	bool bEnabled = trackCurveSelectMenuReset(m_ui.trackCurveSelectMenu);
 	m_ui.trackCurveMenu->setEnabled(bEnabled);
 	m_ui.trackCurveSelectMenu->setEnabled(bEnabled);

--- a/src/qtractorMainForm.h
+++ b/src/qtractorMainForm.h
@@ -186,6 +186,8 @@ public slots:
 	void trackImportMidi();
 	void trackExportAudio();
 	void trackExportMidi();
+	void trackTempoCurveShow();
+
 	void trackCurveSelect(bool On);
 	void trackCurveSelect(QAction *pAction, bool bOn = true);
 	void trackCurveMode(QAction *pAction);

--- a/src/qtractorMainForm.ui
+++ b/src/qtractorMainForm.ui
@@ -285,6 +285,8 @@
        <string>M&amp;ode</string>
       </property>
      </widget>
+     <addaction name="trackTempoCurveShowAction"/>
+     <addaction name="separator"/>
      <addaction name="trackCurveSelectMenu"/>
      <addaction name="separator" />
      <addaction name="separator"/>
@@ -1564,6 +1566,30 @@
    </property>
    <property name="statusTip">
     <string>Automation curve color</string>
+   </property>
+  </action>
+  <action name="trackTempoCurveShowAction">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="qtractor.qrc">
+     <normaloff>:/images/trackCurveEnabled.png</normaloff>
+     <normalon>:/images/trackCurveProcess.png</normalon>
+     <disabledoff>:/images/trackCurveNone.png</disabledoff>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Tempo</string>
+   </property>
+   <property name="iconText">
+    <string>Tempo curve</string>
+   </property>
+   <property name="toolTip">
+    <string>Tempo curve</string>
+   </property>
+   <property name="statusTip">
+    <string>Tempo curve</string>
    </property>
   </action>
   <action name="trackCurveLockedAction">

--- a/src/qtractorMidiControl.cpp
+++ b/src/qtractorMidiControl.cpp
@@ -343,7 +343,7 @@ bool qtractorMidiControl::processEvent ( const qtractorCtlEvent& ctle )
 	case TRACK_GAIN:
 		fValue = scale.valueFromMidi(ctle.value());
 		fOldValue = pTrack->gain();
-		if (pTrack->trackType() == qtractorTrack::Audio && !val.isDelta())
+		if ((pTrack->trackType() == qtractorTrack::Audio && !val.isDelta()) || (pTrack->trackType() == qtractorTrack::Tempo && !val.isDelta()))
 			fValue = ::cubef2(fValue);
 		if (ctlv.syncDecimal(fValue, fOldValue, val.isDelta())) {
 			bResult = pSession->execute(
@@ -478,7 +478,7 @@ void qtractorMidiControl::sendTrackController (
 
 	switch (command) {
 	case TRACK_GAIN:
-		if (pTrack->trackType() == qtractorTrack::Audio)
+		if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Tempo))
 			iValue = scale.midiFromValue(::cbrtf2(pTrack->gain()));
 		else
 			iValue = scale.midiFromValue(pTrack->gain());

--- a/src/qtractorMidiControlObserver.h
+++ b/src/qtractorMidiControlObserver.h
@@ -107,6 +107,12 @@ public:
 	qtractorCurveList *curveList() const
 		{ return m_pCurveList; }
 
+	// Special indirect tempo curve accessors.
+	void setTempoCurve(qtractorTempoCurve *pTempoCurve)
+		{ m_pTempoCurve = pTempoCurve; }
+	qtractorTempoCurve *tempoCurve() const
+		{ return m_pTempoCurve; }
+
 protected:
 
 	// Updater.
@@ -144,6 +150,9 @@ private:
 
 	// Special indirect automation relatives.
 	qtractorCurveList *m_pCurveList;
+
+	// Special indirect tempo curve.
+	qtractorTempoCurve *m_pTempoCurve;
 };
 
 

--- a/src/qtractorMixer.cpp
+++ b/src/qtractorMixer.cpp
@@ -358,6 +358,7 @@ void qtractorMixerStrip::initMixerStrip (void)
 	m_pMidiLabel = NULL;
 	int iFixedWidth = 54;
 	switch (meterType) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio: {
 		// Type cast for proper audio monitor...
 		qtractorAudioMonitor *pAudioMonitor = NULL;
@@ -498,7 +499,7 @@ void qtractorMixerStrip::setMonitor ( qtractorMonitor *pMonitor )
 		meterType = m_pTrack->trackType();
 	else if (m_pBus)
 		meterType = m_pBus->busType();
-	if (meterType == qtractorTrack::Audio) {
+	if ((meterType == qtractorTrack::Audio) || (meterType == qtractorTrack::Tempo)) {
 		qtractorAudioMonitor *pAudioMonitor
 			= static_cast<qtractorAudioMonitor *> (pMonitor);
 		if (pAudioMonitor) {
@@ -551,6 +552,7 @@ void qtractorMixerStrip::updateName (void)
 
 	QString sType;
 	switch (meterType) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		if (icon.isNull())
 			icon.load(":/images/trackAudio.png");

--- a/src/qtractorObserver.cpp
+++ b/src/qtractorObserver.cpp
@@ -118,7 +118,7 @@ static qtractorSubjectQueue g_subjectQueue;
 qtractorSubject::qtractorSubject ( float fValue, float fDefaultValue )
 	: m_fValue(fValue), m_bQueued(false), m_fPrevValue(fValue),
 		m_fMinValue(0.0f), m_fMaxValue(1.0f), m_fDefaultValue(fDefaultValue),
-		m_bToggled(false), m_bInteger(false), m_pCurve(NULL)
+		m_bToggled(false), m_bInteger(false), m_pCurve(NULL), m_pTempoCurve(NULL)
 {
 }
 

--- a/src/qtractorObserver.h
+++ b/src/qtractorObserver.h
@@ -32,6 +32,7 @@
 class qtractorSubject;
 class qtractorObserver;
 class qtractorCurve;
+class qtractorTempoCurve;
 
 
 //---------------------------------------------------------------------------
@@ -150,6 +151,12 @@ public:
 	qtractorCurve *curve() const
 		{ return m_pCurve; }
 
+	// Tempo curve association.
+	void setTempoCurve(qtractorTempoCurve *pTempoCurve)
+		{ m_pTempoCurve = pTempoCurve; }
+	qtractorTempoCurve *tempoCurve() const
+		{ return m_pTempoCurve; }
+
 	// Queue flush (singleton) -- notify all pending observers.
 	static void flushQueue(bool bUpdate);
 	
@@ -183,6 +190,9 @@ private:
 
 	// Automation curve association.
 	qtractorCurve *m_pCurve;
+
+	// Tempo curve association.
+	qtractorTempoCurve *m_pTempoCurve;
 
 	// List of observers (obviously)
 	QList<qtractorObserver *> m_observers;
@@ -274,6 +284,12 @@ public:
 		{ if (m_pSubject) m_pSubject->setCurve(pCurve); }
 	qtractorCurve *curve() const
 		{ return (m_pSubject ? m_pSubject->curve() : NULL); }
+
+	// Tempo curve association.
+	void setTempoCurve(qtractorTempoCurve *pTempoCurve)
+		{ if (m_pSubject) m_pSubject->setTempoCurve(pTempoCurve); }
+	qtractorTempoCurve *tempoCurve() const
+		{ return (m_pSubject ? m_pSubject->tempoCurve() : NULL); }
 
 	// Pure virtual view updater.
 	virtual void update(bool bUpdate) = 0;

--- a/src/qtractorSession.cpp
+++ b/src/qtractorSession.cpp
@@ -2358,6 +2358,9 @@ bool qtractorSession::loadElement (
 					if (!pTrack->loadElement(pDocument, &eTrack))
 						return false;
 					qtractorSession::addTrack(pTrack);
+					if ((pTrack->trackType() == qtractorTrack::Tempo) && (pTrack->isSolo())) {
+						updateTempoTrackSolo(pTrack, true);
+					}
 				}
 			}
 			// Stabilize things a bit...

--- a/src/qtractorSession.h
+++ b/src/qtractorSession.h
@@ -25,6 +25,7 @@
 #include "qtractorAtomic.h"
 #include "qtractorTrack.h"
 #include "qtractorTimeScale.h"
+#include "qtractorTempoCurve.h"
 
 #include <QHash>
 
@@ -85,8 +86,18 @@ public:
 	unsigned long sessionStart() const;
 	unsigned long sessionEnd() const;
 
-	// Time-scale helper accessors.
-	qtractorTimeScale *timeScale();
+	// Time-scale accessor.
+	qtractorTimeScale *timeScale() const;
+
+	// Tempo-curve helper accessors.
+	void setSessionTempoCurve(qtractorTempoCurve *pTempoCurve);
+	qtractorTempoCurve *sessionTempoCurve();
+
+	// TEMPO track muting maintenance method.
+	void updateTempoTrackMute(qtractorTrack *pTempoTrack, bool bMute);
+
+	// TEMPO track soloing maintenance method.
+	void updateTempoTrackSolo(qtractorTrack *pTempoTrack, bool bForceSolo = false);
 
 	// Device engine common client name accessors.
 	void setClientName(const QString& sClientName);
@@ -367,7 +378,7 @@ public:
 	{
 		// Default constructor.
 		Properties()
-			{ clear(); }
+			{ m_pTempoCurve = NULL; clear(); }
 		// Copy constructor.
 		Properties(const Properties& props)
 			{ copy(props); }
@@ -378,12 +389,15 @@ public:
 		Properties& copy(const Properties& props);
 		// Helper clear/reset method.
 		void clear();
+		// Time-scale accessor.
+		qtractorTimeScale *timeScale() const;
 		// Members.
 		QString sessionDir;
 		QString sessionName;
 		QString description;
 		// Intrinsic time scale.
-		qtractorTimeScale timeScale;
+		qtractorTimeScale m_timeScale;
+		qtractorTempoCurve *m_pTempoCurve;
 	};
 
 	// Alternate properties accessor.

--- a/src/qtractorSessionCommand.cpp
+++ b/src/qtractorSessionCommand.cpp
@@ -152,9 +152,9 @@ qtractorSessionEditCommand::qtractorSessionEditCommand (
 			name(), pSession->properties(), properties);
 
 	// Append tempo/time-siganture changes...
-	const float fTempo = properties.timeScale.tempo();
-	const unsigned short iBeatsPerBar = properties.timeScale.beatsPerBar();
-	const unsigned short iBeatDivisor = properties.timeScale.beatDivisor();
+	const float fTempo = properties.timeScale()->tempo();
+	const unsigned short iBeatsPerBar = properties.timeScale()->beatsPerBar();
+	const unsigned short iBeatDivisor = properties.timeScale()->beatDivisor();
 	if (pSession->tempo() != fTempo ||
 		pSession->beatsPerBar() != iBeatsPerBar ||
 		pSession->beatDivisor() != iBeatDivisor) {
@@ -166,7 +166,7 @@ qtractorSessionEditCommand::qtractorSessionEditCommand (
 	}
 
 	// Append time resolution changes too...
-	const unsigned short iTicksPerBeat = properties.timeScale.ticksPerBeat();
+	const unsigned short iTicksPerBeat = properties.timeScale()->ticksPerBeat();
 	if (pSession->ticksPerBeat() != iTicksPerBeat)
 		m_iTicksPerBeat = iTicksPerBeat;
 }

--- a/src/qtractorSessionCursor.cpp
+++ b/src/qtractorSessionCursor.cpp
@@ -93,7 +93,10 @@ void qtractorSessionCursor::seek ( unsigned long iFrame, bool bSync )
 		// Update cursor track clip...
 		m_ppClips[iTrack] = pClip;
 		// Now something fulcral for clips around...
-		if (pTrack->trackType() == m_syncType) {
+		if (
+			(pTrack->trackType() == m_syncType) ||
+			((m_syncType == qtractorTrack::Audio) && (pTrack->trackType() == qtractorTrack::Tempo))
+		) {
 			// Tell whether play-head is after loop-start position...
 			const bool bLooping = (iFrame >= m_pSession->loopStart());
 			// Care for old/previous clip...
@@ -210,7 +213,8 @@ void qtractorSessionCursor::updateTrack ( qtractorTrack *pTrack )
 	const int iTrack = m_pSession->tracks().find(pTrack);
 	if (iTrack >= 0) {
 		qtractorClip *pClip = seekClip(pTrack, NULL, m_iFrame);
-		if (pClip && pTrack->trackType() == m_syncType
+		if (pClip
+			&& ((pTrack->trackType() == m_syncType) || ((m_syncType == qtractorTrack::Audio) && (pTrack->trackType() == qtractorTrack::Tempo)))
 			&& m_iFrame >= pClip->clipStart()
 			&& m_iFrame <  pClip->clipStart() + pClip->clipLength()) {
 			pClip->seek(m_iFrame - pClip->clipStart());
@@ -243,7 +247,8 @@ void qtractorSessionCursor::updateTrackClip ( qtractorTrack *pTrack )
 	const int iTrack = m_pSession->tracks().find(pTrack);
 	if (iTrack >= 0) {
 		qtractorClip *pClip = m_ppClips[iTrack];
-		if (pClip && pTrack->trackType() == m_syncType) {
+		if (pClip
+			&& ((pTrack->trackType() == m_syncType) || ((m_syncType == qtractorTrack::Audio) && (pTrack->trackType() == qtractorTrack::Tempo)))) {
 			if (m_iFrame >= pClip->clipStart() &&
 				m_iFrame <  pClip->clipStart() + pClip->clipLength()) {
 				pClip->seek(m_iFrame - pClip->clipStart());
@@ -264,7 +269,8 @@ void qtractorSessionCursor::updateClips ( qtractorClip **ppClips,
 	qtractorTrack *pTrack = m_pSession->tracks().first();
 	while (pTrack && iTrack < iTracks) {
 		qtractorClip *pClip = seekClip(pTrack, NULL, m_iFrame);
-		if (pClip && pTrack->trackType() == m_syncType
+		if (pClip
+			&& ((pTrack->trackType() == m_syncType) || ((m_syncType == qtractorTrack::Audio) && (pTrack->trackType() == qtractorTrack::Tempo)))
 			&& m_iFrame >= pClip->clipStart()
 			&& m_iFrame <  pClip->clipStart() + pClip->clipLength()) {
 			pClip->seek(m_iFrame - pClip->clipStart());

--- a/src/qtractorSessionForm.cpp
+++ b/src/qtractorSessionForm.cpp
@@ -141,19 +141,19 @@ void qtractorSessionForm::setSession ( qtractorSession *pSession )
 	m_ui.DescriptionTextEdit->setPlainText(m_props.description);
 	// Time properties...
 	m_ui.SampleRateComboBox->setEditText(
-		QString::number(m_props.timeScale.sampleRate()));
+		QString::number(m_props.timeScale()->sampleRate()));
 	m_ui.SampleRateTextLabel->setEnabled(!pSession->isActivated());
 	m_ui.SampleRateComboBox->setEnabled(!pSession->isActivated());
-	m_ui.TempoSpinBox->setTempo(m_props.timeScale.tempo(), false);
-	m_ui.TempoSpinBox->setBeatsPerBar(m_props.timeScale.beatsPerBar(), false);
-	m_ui.TempoSpinBox->setBeatDivisor(m_props.timeScale.beatDivisor(), false);
-	m_ui.TicksPerBeatSpinBox->setValue(int(m_props.timeScale.ticksPerBeat()));
+	m_ui.TempoSpinBox->setTempo(m_props.timeScale()->tempo(), false);
+	m_ui.TempoSpinBox->setBeatsPerBar(m_props.timeScale()->beatsPerBar(), false);
+	m_ui.TempoSpinBox->setBeatDivisor(m_props.timeScale()->beatDivisor(), false);
+	m_ui.TicksPerBeatSpinBox->setValue(int(m_props.timeScale()->ticksPerBeat()));
 	// View properties...
 	m_ui.SnapPerBeatComboBox->setCurrentIndex(
-		qtractorTimeScale::indexFromSnap(m_props.timeScale.snapPerBeat()));
-	m_ui.PixelsPerBeatSpinBox->setValue(int(m_props.timeScale.pixelsPerBeat()));
-	m_ui.HorizontalZoomSpinBox->setValue(int(m_props.timeScale.horizontalZoom()));
-	m_ui.VerticalZoomSpinBox->setValue(int(m_props.timeScale.verticalZoom()));
+		qtractorTimeScale::indexFromSnap(m_props.timeScale()->snapPerBeat()));
+	m_ui.PixelsPerBeatSpinBox->setValue(int(m_props.timeScale()->pixelsPerBeat()));
+	m_ui.HorizontalZoomSpinBox->setValue(int(m_props.timeScale()->horizontalZoom()));
+	m_ui.VerticalZoomSpinBox->setValue(int(m_props.timeScale()->verticalZoom()));
 
 	// Start editing session name, if empty...
 	if (m_props.sessionName.isEmpty())
@@ -200,19 +200,19 @@ void qtractorSessionForm::accept (void)
 		m_props.sessionDir  = m_ui.SessionDirComboBox->currentText();
 		m_props.description = m_ui.DescriptionTextEdit->toPlainText().trimmed();
 		// Time properties...
-		m_props.timeScale.setSampleRate(
+		m_props.timeScale()->setSampleRate(
 			m_ui.SampleRateComboBox->currentText().toUInt());
-		m_props.timeScale.setTempo(m_ui.TempoSpinBox->tempo());
-		m_props.timeScale.setBeatType(2);
-		m_props.timeScale.setBeatsPerBar(m_ui.TempoSpinBox->beatsPerBar());
-		m_props.timeScale.setBeatDivisor(m_ui.TempoSpinBox->beatDivisor());
-		m_props.timeScale.setTicksPerBeat(m_ui.TicksPerBeatSpinBox->value());
+		m_props.timeScale()->setTempo(m_ui.TempoSpinBox->tempo());
+		m_props.timeScale()->setBeatType(2);
+		m_props.timeScale()->setBeatsPerBar(m_ui.TempoSpinBox->beatsPerBar());
+		m_props.timeScale()->setBeatDivisor(m_ui.TempoSpinBox->beatDivisor());
+		m_props.timeScale()->setTicksPerBeat(m_ui.TicksPerBeatSpinBox->value());
 		// View properties...
-		m_props.timeScale.setSnapPerBeat(qtractorTimeScale::snapFromIndex(
+		m_props.timeScale()->setSnapPerBeat(qtractorTimeScale::snapFromIndex(
 			m_ui.SnapPerBeatComboBox->currentIndex()));
-		m_props.timeScale.setPixelsPerBeat(m_ui.PixelsPerBeatSpinBox->value());
-		m_props.timeScale.setHorizontalZoom(m_ui.HorizontalZoomSpinBox->value());
-		m_props.timeScale.setVerticalZoom(m_ui.VerticalZoomSpinBox->value());
+		m_props.timeScale()->setPixelsPerBeat(m_ui.PixelsPerBeatSpinBox->value());
+		m_props.timeScale()->setHorizontalZoom(m_ui.HorizontalZoomSpinBox->value());
+		m_props.timeScale()->setVerticalZoom(m_ui.VerticalZoomSpinBox->value());
 		// Reset dirty flag.
 		m_iDirtyCount = 0;
 	}

--- a/src/qtractorTempoCurve.cpp
+++ b/src/qtractorTempoCurve.cpp
@@ -1,0 +1,194 @@
+// qtractorTempoCurve.cpp
+//
+/****************************************************************************
+   Copyright (C) 2005-2018, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2018, spog aka Samo Pogačnik. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#include "qtractorSession.h"
+#include "qtractorTempoCurve.h"
+
+#include <math.h>
+
+
+// Ref. P.448. Approximate cube root of an IEEE float
+// Hacker's Delight (2nd Edition), by Henry S. Warren
+// http://www.hackersdelight.org/hdcodetxt/acbrt.c.txt
+//
+static inline float cbrtf2 ( float x )
+{
+#ifdef CONFIG_FLOAT32//_NOP
+	// Avoid strict-aliasing optimization (gcc -O2).
+	union { float f; int i; } u;
+	u.f  = x;
+	u.i  = (u.i >> 4) + (u.i >> 2);
+	u.i += (u.i >> 4) + 0x2a6497f8;
+	return 0.33333333f * (2.0f * u.f + x / (u.f * u.f));
+//	return u.f;
+#else
+	return ::cbrtf(x);
+#endif
+}
+
+static inline float cubef2 ( float x )
+{
+	return x * x * x;
+}
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurve -- The generic curve declaration.
+//
+
+// Constructor.
+qtractorTempoCurve::qtractorTempoCurve ( qtractorTimeScale *pTimeScale, qtractorSubject *pSubject )
+		: /*m_pTimeScale(pTimeScale), */m_observer(pSubject, this), m_state(Idle)/*, m_cursor(this)*/,
+		m_color(Qt::darkRed), m_pEditList(NULL)
+{
+
+	if (pTimeScale)
+		m_pTimeScale = new qtractorTimeScale(*pTimeScale);
+	else
+		m_pTimeScale = new qtractorTimeScale();
+
+	m_pEditList = new qtractorTempoCurveEditList(this);
+
+	m_observer.setTempoCurve(this);
+
+}
+
+// Destructor.
+qtractorTempoCurve::~qtractorTempoCurve (void)
+{
+
+	m_observer.setCurve(NULL);
+
+}
+
+
+// Common interpolate method.
+float qtractorTempoCurve::value ( const qtractorTimeScale::Node *pNode, unsigned long iFrame ) const
+{
+	if (pNode == NULL) {
+		pNode = m_pTimeScale->nodes().last();
+		if (pNode == NULL)
+			return 0;
+	}
+
+	const float x = float(pNode->frame) - float(iFrame);
+
+	float y = pNode->currTempo();
+	if (x > 0.0f) {
+		y = pNode->prevTempo();
+	}
+
+	return y;
+}
+
+
+float qtractorTempoCurve::value ( unsigned long iFrame )
+{
+	return value(m_pTimeScale->cursor().seekFrame(iFrame), iFrame);
+}
+
+
+// Normalized scale converters.
+float qtractorTempoCurve::valueFromScale ( float fScale ) const 
+{
+	return m_observer.valueFromScale(fScale);
+}
+
+
+float qtractorTempoCurve::scaleFromValue ( float fValue ) const
+{
+	return m_observer.scaleFromValue(fValue);
+}
+
+
+void qtractorTempoCurve::setProcess ( bool bProcess )
+{
+#ifdef CONFIG_DEBUG_0
+	qDebug("qtractorTempoCurve[%p]::setProcess(%d)", this, int(bProcess));
+#endif
+
+	const bool bOldProcess = (m_state & Process);
+	m_state = State(bProcess ? (m_state | Process) : (m_state & ~Process));
+	if ((bProcess && !bOldProcess) || (!bProcess && bOldProcess)) {
+		// notify auto-plugin-deactivate
+		qtractorSession *pSession = qtractorSession::getInstance();
+		if (pSession)
+			pSession->autoDeactivatePlugins();
+	}
+}
+
+
+void qtractorTempoCurve::setLocked ( bool bLocked )
+{
+#ifdef CONFIG_DEBUG_0
+	qDebug("qtractorTempoCurve[%p]::setLocked(%d)", this, int(bLocked));
+#endif
+
+	const bool bOldLocked = (m_state & Locked);
+	m_state = State(bLocked ? (m_state | Locked) : (m_state & ~Locked));
+}
+
+
+//----------------------------------------------------------------------
+// qtractorTempoCurveEditList -- Curve node edit list.
+
+// Curve edit list command executive.
+bool qtractorTempoCurveEditList::execute ( bool bRedo )
+{
+	if (m_pTempoCurve == NULL)
+		return false;
+
+	QListIterator<Item *> iter(m_items);
+	if (!bRedo)
+		iter.toBack();
+	while (bRedo ? iter.hasNext() : iter.hasPrevious()) {
+		Item *pItem = (bRedo ? iter.next() : iter.previous());
+		// Execute the command item...
+		switch (pItem->command)	{
+		case AddNode: {
+			pItem->autoDelete = !bRedo;
+			break;
+		}
+		case MoveNode: {
+			qtractorTimeScale::Node *pNode = pItem->node;
+			const float fValue = pNode->tempo;
+			const unsigned short iBeatsPerBar = pNode->beatsPerBar;
+			const unsigned short iBeatDivisor = pNode->beatDivisor;
+			pNode->tempo = pItem->tempo;
+			pNode->beatsPerBar = pItem->beatsPerBar;
+			pNode->beatDivisor = pItem->beatDivisor;
+			break;
+		}
+		case RemoveNode: {
+			pItem->autoDelete = bRedo;
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	return true;
+}
+
+
+// end of qtractorTempoCurve.cpp

--- a/src/qtractorTempoCurve.h
+++ b/src/qtractorTempoCurve.h
@@ -1,0 +1,272 @@
+// qtractorTempoCurve.h
+//
+/****************************************************************************
+   Copyright (C) 2005-2018, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2018, spog aka Samo Pogačnik. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#ifndef __qtractorTempoCurve_h
+#define __qtractorTempoCurve_h
+
+#include "qtractorObserver.h"
+#include "qtractorMidiSequence.h"
+
+#include <QColor>
+#include <QObject>
+
+#include "qtractorTimeScale.h"
+
+
+// Forward declarations.
+class qtractorTimeScale;
+
+class qtractorTempoCurveEditList;
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurve -- The tempo curve declaration.
+//
+
+class qtractorTempoCurve : public qtractorList<qtractorTempoCurve>::Link
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurve(qtractorTimeScale *pTimeScale, qtractorSubject *pSubject);
+
+	// Destructor.
+	~qtractorTempoCurve();
+
+	// Curve subject accessors.
+	void setSubject(qtractorSubject *pSubject)
+		{ m_observer.setSubject(pSubject); }
+	qtractorSubject *subject() const
+		{ return m_observer.subject(); }
+
+	// Time-scale accessor.
+	qtractorTimeScale *timeScale() const { return m_pTimeScale; }
+
+	// Curve list reset method.
+	void clear();
+
+	// Master seeker method.
+	qtractorTimeScale::Node *seek(unsigned long iFrame)
+		{ return m_pTimeScale->cursor().seekFrame(iFrame); }
+
+	// Common interpolate methods.
+	float value(const qtractorTimeScale::Node *pNode, unsigned long iFrame) const;
+	float value(unsigned long iFrame);
+
+	// Normalized scale converters.
+	float valueFromScale(float fScale) const;
+	float scaleFromValue(float fValue) const;
+
+	// Common normalized methods.
+	float scale(const qtractorTimeScale::Node *pNode, unsigned long iFrame) const
+		{ return scaleFromValue(value(pNode, iFrame)); }
+	float scale(unsigned long iFrame)
+		{ return scaleFromValue(value(iFrame)); }
+
+	float scale(const qtractorTimeScale::Node *pNode) const
+		{ return scaleFromValue(pNode->tempo); }
+
+	// Refresh all coefficients.
+	void update();
+
+	// Curve state flags.
+	enum State { Idle = 0, Process = 1, Locked = 2 };
+
+	bool isIdle() const
+		{ return (m_state == Idle); }
+	bool isProcess() const
+		{ return (m_state & Process); }
+	bool isLocked() const
+		{ return (m_state & Locked); }
+
+	void setProcess(bool bProcess);
+	void setLocked(bool bLocked);
+
+	// The meta-processing automation procedure.
+	void process(unsigned long iFrame)
+	{
+		if (isProcess()) {
+			qtractorTimeScale::Node *pNode = seek(iFrame);
+				m_observer.setValue(value(pNode, iFrame));
+		}
+	}
+
+	// Curve mode accessor.
+	void setColor(const QColor& color)
+		{ m_color = color; }
+	const QColor& color() const
+		{ return m_color; }
+
+	// Emptyness status.
+	bool isEmpty() const {
+		if (m_pTimeScale)
+			return (m_pTimeScale->nodes().count() < 1);
+		else
+			return true;
+	}
+
+protected:
+	// Node interpolation coefficients updater.
+	void updateNode(qtractorTimeScale::Node *pNode);
+	void updateNodeEx(qtractorTimeScale::Node *pNode);
+
+	// Observer for capture.
+	class Observer : public qtractorObserver
+	{
+	public:
+
+		// Constructor.
+		Observer(qtractorSubject *pSubject, qtractorTempoCurve *pTempoCurve)
+		    : qtractorObserver(pSubject), m_pTempoCurve(pTempoCurve) {}
+
+		// Capture updater.
+		void update(bool) {}
+
+	private:
+
+		// Own curve reference.
+		qtractorTempoCurve *m_pTempoCurve;
+	};
+
+private:
+	// Instance variables...
+	qtractorTimeScale *m_pTimeScale;
+
+	// Capture observer.
+	Observer m_observer;
+
+	// Minimum distance between adjacent nodes.
+	unsigned int m_iMinFrameDist;
+
+	// Curve state.
+	State m_state;
+
+	// Curve color.
+	QColor m_color;
+
+	// Capture (record) edit list.
+	qtractorTempoCurveEditList *m_pEditList;
+};
+
+//----------------------------------------------------------------------
+// qtractorTempCurveEditList -- Curve node edit (command) list.
+
+class qtractorTempoCurveEditList
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveEditList(qtractorTempoCurve *pTempoCurve)
+		: m_pTempoCurve(pTempoCurve) {}
+
+	// Copy cnstructor.
+	qtractorTempoCurveEditList(const qtractorTempoCurveEditList& list)
+		: m_pTempoCurve(list.tempoCurve()) { append(list); }
+
+	// Destructor
+	~qtractorTempoCurveEditList() { clear(); }
+
+	// Curve accessor.
+	qtractorTempoCurve *tempoCurve() const
+		{ return m_pTempoCurve; }
+
+	// List predicate accessor.
+	bool isEmpty() const
+		{ return m_items.isEmpty(); }
+
+	// List methods.
+	void addNode(qtractorTimeScale::Node *pNode)
+		{ m_items.append(new Item(AddNode, pNode, pNode->frame)); }
+	void moveNode(qtractorTimeScale::Node *pNode, float fTempo, unsigned short iBeatsPerBar, unsigned short iBeatDivisor)
+		{ m_items.append(new Item(MoveNode, pNode, fTempo, iBeatsPerBar, iBeatDivisor)); }
+	void removeNode(qtractorTimeScale::Node *pNode)
+		{ m_items.append(new Item(RemoveNode, pNode)); }
+
+	// List appender.
+	void append(const qtractorTempoCurveEditList& list)
+	{
+		QListIterator<Item *> iter(list.m_items);
+		while (iter.hasNext())
+			m_items.append(new Item(*iter.next()));
+	}
+
+	// List cleanup.
+	void clear()
+	{
+		QListIterator<Item *> iter(m_items);
+		while (iter.hasNext()) {
+			Item *pItem = iter.next();
+			if (pItem->autoDelete)
+				delete pItem->node;
+		}
+
+		qDeleteAll(m_items);
+		m_items.clear();
+	}
+
+	// Curve edit list command executive.
+	bool execute(bool bRedo = true);
+
+protected:
+
+	// Primitive command types.
+	enum Command {
+		AddNode, MoveNode, RemoveNode
+	};
+
+	// Curve item struct.
+	struct Item
+	{
+		// Item constructor.
+		Item(Command cmd, qtractorTimeScale::Node *pNode,
+			float fTempo = 120.0f, unsigned short iBeatsPerBar = 4, unsigned short iBeatDivisor = 2)
+			: command(cmd), node(pNode),
+				tempo(fTempo), beatsPerBar(iBeatsPerBar), beatDivisor(iBeatDivisor), autoDelete(false) {}
+
+		// Item copy constructor.
+		Item(const Item& item)
+			: command(item.command), node(item.node),
+				tempo(item.tempo),
+				beatsPerBar(item.beatsPerBar), beatDivisor(item.beatDivisor),
+				autoDelete(item.autoDelete) {}
+
+		// Item members.
+		Command command;
+		qtractorTimeScale::Node *node;
+		float tempo;
+		unsigned short beatsPerBar;
+		unsigned short beatDivisor;
+		bool autoDelete;
+	};
+
+private:
+
+	// Instance variables.
+	qtractorTempoCurve *m_pTempoCurve;
+	QList<Item *>  m_items;
+};
+
+
+#endif  // __qtractorTempCurve_h
+
+
+// end of qtractorTempoCurve.h

--- a/src/qtractorTempoCurveCommand.cpp
+++ b/src/qtractorTempoCurveCommand.cpp
@@ -26,6 +26,7 @@
 #include "qtractorMainForm.h"
 #include "qtractorTracks.h"
 
+#include "qtractorTimeScaleCommand.h"
 #include "qtractorTempoCurveCommand.h"
 
 //----------------------------------------------------------------------
@@ -172,7 +173,24 @@ void qtractorTempoCurveEditCommand::addNode ( qtractorTimeScale::Node *pNode )
 void qtractorTempoCurveEditCommand::moveNode ( qtractorTimeScale::Node *pNode,
 	float fTempo, unsigned short iBeatsPerBar, unsigned short iBeatDivisor )
 {
+#ifdef CONFIG_DEBUG
+	qDebug("qtractorTempoCurveEditCommand::%s@%d: (%g, %u, %u)", __func__, __LINE__,
+		fTempo, iBeatsPerBar, iBeatDivisor);
+#endif
+#if 0
 	m_edits.moveNode(pNode, fTempo, iBeatsPerBar, iBeatDivisor);
+#endif
+
+	qtractorSession *pSession = qtractorSession::getInstance();
+	qtractorTimeScale *pTimeScale = NULL;
+	if (pSession)
+		pTimeScale = pSession->timeScale();
+
+	if (pNode->getTs() == pTimeScale) {
+		// Now, express the change as a undoable command...
+		pSession->execute(new qtractorTimeScaleUpdateNodeCommand(
+			pTimeScale, pNode->frame, fTempo, 2, iBeatsPerBar, iBeatDivisor));
+	}
 }
 
 

--- a/src/qtractorTempoCurveCommand.cpp
+++ b/src/qtractorTempoCurveCommand.cpp
@@ -1,0 +1,218 @@
+// qtractorTempoCurveCommand.cpp
+//
+/****************************************************************************
+   Copyright (C) 2018, spog aka Samo Pogačnik. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#include "qtractorAbout.h"
+
+#include "qtractorSession.h"
+
+#include "qtractorMainForm.h"
+#include "qtractorTracks.h"
+
+#include "qtractorTempoCurveCommand.h"
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveBaseCommand - declaration.
+//
+
+// Constructor.
+qtractorTempoCurveBaseCommand::qtractorTempoCurveBaseCommand ( const QString& sName )
+	: qtractorCommand(sName)
+{
+}
+
+// Virtual command methods.
+bool qtractorTempoCurveBaseCommand::redo (void)
+{
+	return execute(true);
+}
+
+bool qtractorTempoCurveBaseCommand::undo (void)
+{
+	return execute(false);
+}
+
+
+// Virtual command methods.
+bool qtractorTempoCurveBaseCommand::execute ( bool /*bRedo*/ )
+{
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession && !pSession->isPlaying())
+		pSession->process_curve(pSession->playHead());
+
+	qtractorMainForm *pMainForm = qtractorMainForm::getInstance();
+	if (pMainForm) {
+		qtractorTracks *pTracks = pMainForm->tracks();
+		if (pTracks) {
+			pTracks->clearSelect();
+			pTracks->updateTrackList(pTracks->currentTrack());
+		}
+	}
+
+	return true;
+}
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveCommand - declaration.
+//
+
+// Constructor.
+qtractorTempoCurveCommand::qtractorTempoCurveCommand (
+	const QString& sName, qtractorTempoCurve *pTempoCurve )
+	: qtractorTempoCurveBaseCommand(sName), m_pTempoCurve(pTempoCurve)
+{
+}
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveProcessCommand - declaration.
+//
+
+// Constructor.
+qtractorTempoCurveProcessCommand::qtractorTempoCurveProcessCommand (
+	qtractorTempoCurve *pTempoCurve, bool bProcess )
+	: qtractorTempoCurveCommand(QObject::tr("automation play"), pTempoCurve),
+		m_bProcess(bProcess)
+{
+}
+
+
+// Virtual command methods.
+bool qtractorTempoCurveProcessCommand::execute ( bool bRedo )
+{
+	if (m_pTempoCurve == NULL)
+		return false;
+
+	const bool bProcess = m_pTempoCurve->isProcess();
+	m_pTempoCurve->setProcess(m_bProcess);
+	m_bProcess = bProcess;
+
+	return qtractorTempoCurveBaseCommand::execute(bRedo);
+}
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveColorCommand - declaration.
+//
+
+// Constructor.
+qtractorTempoCurveColorCommand::qtractorTempoCurveColorCommand (
+	qtractorTempoCurve *pTempoCurve, const QColor& color )
+	: qtractorTempoCurveCommand(QObject::tr("automation color"), pTempoCurve),
+		m_color(color)
+{
+}
+
+
+// Virtual command methods.
+bool qtractorTempoCurveColorCommand::execute ( bool /*bRedo*/ )
+{
+	if (m_pTempoCurve == NULL)
+		return false;
+
+	const QColor color = m_pTempoCurve->color();
+	m_pTempoCurve->setColor(m_color);
+	m_color = color;
+
+	return true;
+}
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveEditCommand - declaration.
+//
+
+// Constructors.
+qtractorTempoCurveEditCommand::qtractorTempoCurveEditCommand (
+	const QString& sName, qtractorTempoCurve *pTempoCurve )
+	: qtractorTempoCurveCommand(sName, pTempoCurve),
+		m_edits(pTempoCurve)
+{
+}
+
+qtractorTempoCurveEditCommand::qtractorTempoCurveEditCommand ( qtractorTempoCurve *pTempoCurve )
+	: qtractorTempoCurveCommand(QObject::tr("automation edit"), pTempoCurve),
+		m_edits(pTempoCurve)
+{
+}
+
+
+// Destructor.
+qtractorTempoCurveEditCommand::~qtractorTempoCurveEditCommand (void)
+{
+	m_edits.clear();
+}
+
+
+// Primitive command methods.
+void qtractorTempoCurveEditCommand::addNode ( qtractorTimeScale::Node *pNode )
+{
+	m_edits.addNode(pNode);
+}
+
+
+void qtractorTempoCurveEditCommand::moveNode ( qtractorTimeScale::Node *pNode,
+	float fTempo, unsigned short iBeatsPerBar, unsigned short iBeatDivisor )
+{
+	m_edits.moveNode(pNode, fTempo, iBeatsPerBar, iBeatDivisor);
+}
+
+
+void qtractorTempoCurveEditCommand::removeNode ( qtractorTimeScale::Node *pNode )
+{
+	m_edits.removeNode(pNode);
+}
+
+
+// Composite predicate.
+bool qtractorTempoCurveEditCommand::isEmpty (void) const
+{
+	return m_edits.isEmpty();
+}
+
+
+// Common executive method.
+bool qtractorTempoCurveEditCommand::execute ( bool bRedo )
+{
+	if (!m_edits.execute(bRedo))
+		return false;
+
+	return qtractorTempoCurveBaseCommand::execute(bRedo);
+}
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveClearCommand - declaration.
+//
+
+// Constructor.
+qtractorTempoCurveClearCommand::qtractorTempoCurveClearCommand ( qtractorTempoCurve *pTempoCurve )
+	: qtractorTempoCurveEditCommand(QObject::tr("automation clear"), pTempoCurve)
+{
+	qtractorTimeScale::Node *pNode = m_pTempoCurve->timeScale()->nodes().first();
+	while (pNode) {
+		qtractorTempoCurveEditCommand::removeNode(pNode);
+		pNode = pNode->next();
+	}
+}
+
+
+// end of qtractorTempoCurveCommand.cpp

--- a/src/qtractorTempoCurveCommand.h
+++ b/src/qtractorTempoCurveCommand.h
@@ -1,0 +1,171 @@
+// qtractorTempoCurveCommand.h
+//
+/****************************************************************************
+   Copyright (C) 2018, spog aka Samo Pogačnik. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#ifndef __qtractorTempoCurveCommand_h
+#define __qtractorTempoCurveCommand_h
+
+#include "qtractorCommand.h"
+#include "qtractorTempoCurve.h"
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveBaseCommand - declaration.
+//
+
+class qtractorTempoCurveBaseCommand : public qtractorCommand
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveBaseCommand(const QString& sName);
+
+	// Virtual command methods.
+	bool redo();
+	bool undo();
+
+protected:
+
+	// Common executive method.
+	virtual bool execute(bool bRedo);
+};
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveCommand - declaration.
+//
+
+class qtractorTempoCurveCommand : public qtractorTempoCurveBaseCommand
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveCommand(const QString& sName, qtractorTempoCurve *pTempoCurve);
+
+	// Accessor.
+	qtractorTempoCurve *tempoCurve() const { return m_pTempoCurve; }
+
+protected:
+
+	// Instance variables.
+	qtractorTempoCurve *m_pTempoCurve;
+};
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveProcessCommand - declaration.
+//
+
+class qtractorTempoCurveProcessCommand : public qtractorTempoCurveCommand
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveProcessCommand(
+		qtractorTempoCurve *pTempoCurve, bool bProcess);
+
+protected:
+
+	// Virtual executive method.
+	bool execute(bool bRedo);
+
+private:
+
+	// Instance variables.
+	bool m_bProcess;
+};
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveColorCommand - declaration.
+//
+
+class qtractorTempoCurveColorCommand : public qtractorTempoCurveCommand
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveColorCommand(
+		qtractorTempoCurve *pTempoCurve, const QColor& color);
+
+protected:
+
+	// Virtual executive method.
+	bool execute(bool bRedo);
+
+private:
+
+	// Instance variables.
+	QColor m_color;
+};
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveEditCommand - declaration.
+//
+
+class qtractorTempoCurveEditCommand : public qtractorTempoCurveCommand
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveEditCommand(
+		const QString& sName, qtractorTempoCurve *pTempoCurve);
+	qtractorTempoCurveEditCommand(qtractorTempoCurve *pTempoCurve);
+
+	// Destructor.
+	virtual ~qtractorTempoCurveEditCommand();
+
+	// Primitive command methods.
+	void addNode(qtractorTimeScale::Node *pNode);
+	void moveNode(qtractorTimeScale::Node *pNode,
+		float fTempo, unsigned short iBeatsPerBar, unsigned short iBeatDivisor);
+	void removeNode(qtractorTimeScale::Node *pNode);
+
+	// Composite predicate.
+	bool isEmpty() const;
+
+protected:
+	// Virtual executive method.
+	bool execute(bool bRedo);
+
+private:
+	// Instance variables.
+	qtractorTempoCurveEditList m_edits;
+};
+
+
+//----------------------------------------------------------------------
+// class qtractorTempoCurveClearCommand - declaration.
+//
+
+class qtractorTempoCurveClearCommand : public qtractorTempoCurveEditCommand
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveClearCommand(qtractorTempoCurve *pTempoCurve);
+};
+
+
+#endif	// __qtractorTempoCurveCommand_h
+
+// end of qtractorTempoCurveCommand.h
+

--- a/src/qtractorTempoCurveSelect.cpp
+++ b/src/qtractorTempoCurveSelect.cpp
@@ -1,0 +1,167 @@
+// qtractorTempoCurveSelect.cpp
+//
+/****************************************************************************
+   Copyright (C) 2005-2014, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2018, spog aka Samo Pogačnik. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#include "qtractorTempoCurveSelect.h"
+
+
+//-------------------------------------------------------------------------
+// qtractorTempoCurveSelect -- MIDI event selection capsule.
+
+// Constructor.
+qtractorTempoCurveSelect::qtractorTempoCurveSelect (void)
+{
+	m_pTempoCurve = NULL;
+	m_pAnchorNode = NULL;
+}
+
+
+// Default destructor.
+qtractorTempoCurveSelect::~qtractorTempoCurveSelect (void)
+{
+	clear();
+}
+
+
+// Event selection item lookup.
+qtractorTempoCurveSelect::Item *qtractorTempoCurveSelect::findItem (
+	qtractorTimeScale::Node *pNode )
+{
+	// Check if this very event already exists...
+	return m_items.value(pNode, NULL);
+}
+
+
+// Item insertion method.
+void qtractorTempoCurveSelect::addItem (
+	qtractorTimeScale::Node *pNode, const QRect& rectNode )
+{
+	m_items.insert(pNode, new Item(rectNode));
+
+	m_rect = m_rect.united(rectNode);
+	
+	if (m_pAnchorNode == NULL || m_pAnchorNode->frame > pNode->frame)
+		m_pAnchorNode = pNode;
+}
+
+
+// Item removal method.
+void qtractorTempoCurveSelect::removeItem ( qtractorTimeScale::Node *pNode )
+{
+	ItemList::Iterator iter = m_items.find(pNode);
+	if (iter != m_items.end()) {
+		delete iter.value();
+		m_items.erase(iter);
+		commit();
+	}
+}
+
+
+// Item selection method.
+void qtractorTempoCurveSelect::selectItem ( qtractorTempoCurve *pTempoCurve,
+	qtractorTimeScale::Node *pNode, const QRect& rectNode,
+	bool bSelect, bool bToggle )
+{
+	Item *pItem = findItem(pNode);
+	if (pItem) {
+		const unsigned int flags = pItem->flags;
+		if ( (!bSelect && (flags & 2) == 0) ||
+			(( bSelect && (flags & 3) == 3) && bToggle))
+			pItem->flags &= ~1;
+		else
+		if ( ( bSelect && (flags & 2) == 0) ||
+			((!bSelect && (flags & 3) == 2) && bToggle))
+			pItem->flags |=  1;
+	}
+	else
+	if (bSelect) {
+		if (m_pTempoCurve == NULL)
+			m_pTempoCurve  = pTempoCurve;
+		if (m_pTempoCurve == pTempoCurve)
+			addItem(pNode, rectNode);
+	}
+}
+
+
+// Selection commit method.
+void qtractorTempoCurveSelect::update ( bool bCommit )
+{
+	// Remove unselected...
+	int iUpdate = 0;
+
+	ItemList::Iterator iter = m_items.begin();
+	const ItemList::Iterator& iter_end = m_items.end();
+	while (iter != iter_end) {
+		Item *pItem = iter.value();
+		if (bCommit) {
+			if (pItem->flags & 1)
+				pItem->flags |=  2;
+			else
+				pItem->flags &= ~2;
+		}
+		if ((pItem->flags & 3) == 0) {
+			delete pItem;
+			iter = m_items.erase(iter);
+			++iUpdate;
+		}
+		else ++iter;
+	}
+
+	// Did we remove any?
+	if (iUpdate > 0)
+		commit();
+}
+
+
+// Selection commit method.
+void qtractorTempoCurveSelect::commit (void)
+{
+	// Reset united selection rectangle...
+	m_rect.setRect(0, 0, 0, 0);
+
+	ItemList::ConstIterator iter = m_items.constBegin();
+	const ItemList::ConstIterator iter_end = m_items.constEnd();
+	for ( ; iter != iter_end; ++iter) {
+		Item *pItem = iter.value();
+		m_rect = m_rect.united(pItem->rectNode);
+	}
+
+	if (m_items.isEmpty()) {
+		m_pAnchorNode = NULL;
+		m_pTempoCurve = NULL;
+	}
+}
+
+
+// Reset event selection.
+void qtractorTempoCurveSelect::clear (void)
+{
+	m_rect.setRect(0, 0, 0, 0);
+
+	qDeleteAll(m_items);
+	m_items.clear();
+
+	m_pAnchorNode = NULL;
+	m_pTempoCurve = NULL;
+}
+
+
+// end of qtractorTempoCurveSelect.cpp

--- a/src/qtractorTempoCurveSelect.h
+++ b/src/qtractorTempoCurveSelect.h
@@ -1,0 +1,119 @@
+// qtractorTempoCurveSelect.h
+//
+/****************************************************************************
+   Copyright (C) 2005-2014, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2018, spog aka Samo Pogačnik. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+*****************************************************************************/
+
+#ifndef __qtractorTempoCurveSelect_h
+#define __qtractorTempoCurveSelect_h
+
+#include "qtractorTempoCurve.h"
+
+#include <QHash>
+#include <QRect>
+
+
+//-------------------------------------------------------------------------
+// qtractorTempoCurveSelect -- MIDI event selection capsule.
+
+class qtractorTempoCurveSelect
+{
+public:
+
+	// Constructor.
+	qtractorTempoCurveSelect();
+
+	// Default destructor.
+	~qtractorTempoCurveSelect();
+
+	// Selection item struct.
+	struct Item
+	{
+		// Item constructor.
+		Item(const QRect& rect): rectNode(rect), flags(1) {}
+
+		// Item members.
+		QRect rectNode;
+		unsigned int flags;
+	};
+
+	typedef QHash<qtractorTimeScale::Node *, Item *> ItemList;
+
+	// Event selection item lookup.
+	Item *findItem(qtractorTimeScale::Node *pNode);
+
+	// Event insertion method.
+	void addItem(qtractorTimeScale::Node *pNode, const QRect& rectNode);
+
+	// Event removal method.
+	void removeItem(qtractorTimeScale::Node *pNode);
+
+	// Event selection method.
+	void selectItem(qtractorTempoCurve *pTempoCurve,
+		qtractorTimeScale::Node *pNode, const QRect& rectNode,
+		bool bSelect = true, bool bToggle = false);
+
+	// The united selection rectangle.
+	const QRect& rect() const { return m_rect; }
+
+	// Selection list accessor.
+	const ItemList& items() const { return m_items; }
+
+	// Selection update method.
+	void update(bool bCommit);
+
+	// Selection commit method.
+	void commit();
+
+	// Reset event selection.
+	void clear();
+
+	// Selection curve accessors.
+	void setTempoCurve ( qtractorTempoCurve *pTempoCurve )
+		{ m_pTempoCurve = pTempoCurve; }
+	qtractorTempoCurve *tempoCurve() const
+		{ return m_pTempoCurve; }
+
+	qtractorTimeScale::Node *anchorNode() const
+		{ return m_pAnchorNode; }
+
+	// Selection curve testimony.
+	bool isCurrentCurve ( qtractorTempoCurve *pTempoCurve ) const
+		{ return (m_pTempoCurve && m_pTempoCurve == pTempoCurve); }
+
+private:
+
+	// The node selection list.
+	ItemList m_items;
+
+	// The united selection rectangle.
+	QRect m_rect;
+
+	// There must be only one curve.
+	qtractorTempoCurve *m_pTempoCurve;
+
+	// The most probable anchor node.
+	qtractorTimeScale::Node *m_pAnchorNode;
+};
+
+
+#endif  // __qtractorTempoCurveSelect_h
+
+
+// end of qtractorTempoCurveSelect.h

--- a/src/qtractorTimeScale.cpp
+++ b/src/qtractorTimeScale.cpp
@@ -67,7 +67,7 @@ void qtractorTimeScale::clear (void)
 		m_iHorizontalZoom = pTimeScale->m_iHorizontalZoom;
 		m_iVerticalZoom   = pTimeScale->m_iVerticalZoom;
 
-//		m_displayFormat   = pTimeScale->m_displayFormat;
+		m_displayFormat   = pTimeScale->m_displayFormat;
 
 		m_iSampleRate     = pTimeScale->m_iSampleRate;
 		m_iTicksPerBeat   = pTimeScale->m_iTicksPerBeat;

--- a/src/qtractorTimeScale.cpp
+++ b/src/qtractorTimeScale.cpp
@@ -22,6 +22,7 @@
 #include "qtractorTimeScale.h"
 #include <QObject>
 
+#include "qtractorSession.h"
 
 //----------------------------------------------------------------------
 // class qtractorTimeScale -- Time scale conversion helper class.
@@ -59,18 +60,35 @@ void qtractorTimeScale::reset (void)
 // (Re)nitializer method.
 void qtractorTimeScale::clear (void)
 {
-	m_iSnapPerBeat    = 4;
-	m_iHorizontalZoom = 100;
-	m_iVerticalZoom   = 100;
+	qtractorTimeScale *pTimeScale;
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession && (pTimeScale = pSession->timeScale())) {
+		m_iSnapPerBeat    = pTimeScale->m_iSnapPerBeat;
+		m_iHorizontalZoom = pTimeScale->m_iHorizontalZoom;
+		m_iVerticalZoom   = pTimeScale->m_iVerticalZoom;
 
-//	m_displayFormat   = Frames;
+//		m_displayFormat   = pTimeScale->m_displayFormat;
 
-	m_iSampleRate     = 44100;
-	m_iTicksPerBeat   = 960;
-	m_iPixelsPerBeat  = 32;
+		m_iSampleRate     = pTimeScale->m_iSampleRate;
+		m_iTicksPerBeat   = pTimeScale->m_iTicksPerBeat;
+		m_iPixelsPerBeat  = pTimeScale->m_iPixelsPerBeat;
 
-	// Clear/reset tempo-map...
-	reset();
+		// Clear/reset tempo-map...
+		reset();
+	} else {
+		m_iSnapPerBeat    = 4;
+		m_iHorizontalZoom = 100;
+		m_iVerticalZoom   = 100;
+
+//		m_displayFormat   = Frames;
+
+		m_iSampleRate     = 44100;
+		m_iTicksPerBeat   = 960;
+		m_iPixelsPerBeat  = 32;
+
+		// Clear/reset tempo-map...
+		reset();
+	}
 }
 
 
@@ -368,20 +386,6 @@ qtractorTimeScale::Node *qtractorTimeScale::addNode (
 		pNode->beatType = iBeatType;
 		pNode->beatsPerBar = iBeatsPerBar;
 		pNode->beatDivisor = iBeatDivisor;
-	} else if (pPrev && pPrev->tempo == fTempo
-		&& pPrev->beatType == iBeatType
-		&& pPrev->beatsPerBar == iBeatsPerBar
-		&& pPrev->beatDivisor == iBeatDivisor) {
-		// No need for a new node...
-		return pPrev;
-	} else if (pNext && pNext->tempo == fTempo
-		&& pNext->beatType == iBeatType
-		&& pNext->beatsPerBar == iBeatsPerBar
-		&& pNext->beatDivisor == iBeatDivisor) {
-		// Update next exact matching node...
-		pNode = pNext;
-		pNode->frame = iFrame;
-		pNode->bar = 0;
 	} else {
 		// Add/insert a new node...
 		pNode = new Node(this,

--- a/src/qtractorTimeScale.cpp
+++ b/src/qtractorTimeScale.cpp
@@ -62,7 +62,7 @@ void qtractorTimeScale::clear (void)
 {
 	qtractorTimeScale *pTimeScale;
 	qtractorSession *pSession = qtractorSession::getInstance();
-	if (pSession && (pTimeScale = pSession->timeScale())) {
+	if (pSession && (pTimeScale = pSession->timeScale()) && (pTimeScale != this)) {
 		m_iSnapPerBeat    = pTimeScale->m_iSnapPerBeat;
 		m_iHorizontalZoom = pTimeScale->m_iHorizontalZoom;
 		m_iVerticalZoom   = pTimeScale->m_iVerticalZoom;

--- a/src/qtractorTimeScale.h
+++ b/src/qtractorTimeScale.h
@@ -130,6 +130,11 @@ public:
 		// Update node position metrics.
 		void reset(Node *pNode);
 
+		// Return Nodes owner
+		qtractorTimeScale *getTs() const {
+			return ts;
+		}
+
 		// Node Tempo accessors.
 		float currTempo() const {
 			return tempo;

--- a/src/qtractorTimeScale.h
+++ b/src/qtractorTimeScale.h
@@ -40,7 +40,7 @@ public:
 	enum DisplayFormat { Frames = 0, Time, BBT };
 
 	// Default constructor.
-	qtractorTimeScale() : m_displayFormat(Frames),
+	qtractorTimeScale() : m_displayFormat(Frames), /*m_pTempoCurve(NULL),*/
 		m_cursor(this), m_markerCursor(this) { clear(); }
 
 	// Copy constructor.
@@ -129,6 +129,18 @@ public:
 
 		// Update node position metrics.
 		void reset(Node *pNode);
+
+		// Node Tempo accessors.
+		float currTempo() const {
+			return tempo;
+		}
+
+		float prevTempo() const {
+			if (this->prev())
+				return this->prev()->tempo;
+			else
+				return tempo;
+		}
 
 		// Tempo accessor/convertors.
 		void setTempoEx(float fTempo, unsigned short iBeatType = 2);

--- a/src/qtractorTimeScaleCommand.cpp
+++ b/src/qtractorTimeScaleCommand.cpp
@@ -335,7 +335,7 @@ qtractorClipCommand *qtractorTimeScaleNodeCommand::createClipCommand (
 			if (pClip->clipStart() <  iFrameStart ||
 				pClip->clipStart() >= iFrameEnd)
 				continue;
-			if (pTrack->trackType() == qtractorTrack::Audio) {
+			if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Tempo)) {
 				qtractorAudioClip *pAudioClip
 					= static_cast<qtractorAudioClip *> (pClip);
 				if (pAudioClip) {

--- a/src/qtractorTimeScaleForm.cpp
+++ b/src/qtractorTimeScaleForm.cpp
@@ -21,6 +21,7 @@
 
 #include "qtractorTimeScaleForm.h"
 #include "qtractorTimeScaleCommand.h"
+#include "qtractorTempoCurve.h"
 
 #include "qtractorAbout.h"
 #include "qtractorOptions.h"
@@ -156,6 +157,7 @@ qtractorTimeScaleForm::qtractorTimeScaleForm (
 
 	// Initialize locals.
 	m_pTimeScale  = NULL;
+	m_pTempoCurve = NULL;
 
 	m_pTempoTap   = new QTime();
 	m_iTempoTap   = 0;
@@ -189,8 +191,10 @@ qtractorTimeScaleForm::qtractorTimeScaleForm (
 	// (Re)initial contents.
 	// Default is main session time-scale of course...
 	qtractorSession *pSession = qtractorSession::getInstance();
-	if (pSession)
+	if (pSession) {
 		setTimeScale(pSession->timeScale());
+		setTempoCurve(pSession->sessionTempoCurve());
+	}
 
 	// Try to restore normal window positioning.
 	adjustSize();
@@ -266,6 +270,18 @@ void qtractorTimeScaleForm::setTimeScale ( qtractorTimeScale *pTimeScale )
 qtractorTimeScale *qtractorTimeScaleForm::timeScale (void) const
 {
 	return m_pTimeScale;
+}
+
+
+// Tempo-curve accessor.
+void qtractorTimeScaleForm::setTempoCurve ( qtractorTempoCurve *pTempoCurve )
+{
+	m_pTempoCurve = pTempoCurve;
+}
+
+qtractorTempoCurve *qtractorTimeScaleForm::tempoCurve (void) const
+{
+	return m_pTempoCurve;
 }
 
 
@@ -525,24 +541,10 @@ unsigned int qtractorTimeScaleForm::flags (void) const
 		iFlags |= UpdateNode;
 		if (pNode->prev())
 			iFlags |= RemoveNode;
+		iFlags &= ~AddNode;
 	}
-	if (pNode
-		&& ::fabsf(pNode->tempo - fTempo) < 0.05f
-	//	&& pNode->beatType == iBeatType
-		&& pNode->beatsPerBar == iBeatsPerBar
-		&& pNode->beatDivisor == iBeatDivisor)
-		iFlags &= ~UpdateNode;
 	else
 		iFlags |=  AddNode;
-	if (pNode && pNode->bar == iBar)
-		iFlags &= ~AddNode;
-	if (pNode
-		&& (pNode = pNode->next())	// real assignment
-		&& ::fabsf(pNode->tempo - fTempo) < 0.05f
-	//	&& pNode->beatType == iBeatType
-		&& pNode->beatsPerBar == iBeatsPerBar
-		&& pNode->beatDivisor == iBeatDivisor)
-		iFlags &= ~AddNode;
 
 	const unsigned long iFrame = m_pTimeScale->frameFromBar(iBar);
 	qtractorTimeScale::Marker *pMarker

--- a/src/qtractorTimeScaleForm.h
+++ b/src/qtractorTimeScaleForm.h
@@ -27,6 +27,7 @@
 
 // Forward declarations...
 class qtractorTimeScaleListItem;
+class qtractorTempoCurve;
 
 class QTime;
 
@@ -45,6 +46,9 @@ public:
 
 	void setTimeScale(qtractorTimeScale *pTimeScale);
 	qtractorTimeScale *timeScale() const;
+
+	void setTempoCurve(qtractorTempoCurve *pTempoCurve);
+	qtractorTempoCurve *tempoCurve() const;
 
 	void setFrame(unsigned long iFrame);
 	unsigned long frame() const;
@@ -107,6 +111,7 @@ private:
 
 	// Instance variables...
 	qtractorTimeScale *m_pTimeScale;
+	qtractorTempoCurve *m_pTempoCurve;
 
 	QTime *m_pTempoTap;
 	int    m_iTempoTap;

--- a/src/qtractorTrack.h
+++ b/src/qtractorTrack.h
@@ -44,6 +44,7 @@ class qtractorAudioBufferThread;
 class qtractorCurveList;
 class qtractorCurveFile;
 class qtractorCurve;
+class qtractorTempoCurve;
 
 // Special forward declarations.
 class QDomElement;
@@ -59,7 +60,7 @@ class qtractorTrack : public qtractorList<qtractorTrack>::Link
 public:
 
 	// Track type symbology.
-	enum TrackType { None = 0, Audio, Midi };
+	enum TrackType { None = 0, Audio, Midi, Tempo };
 	// Tool button specific types:
 	enum ToolType  { Record, Mute, Solo };
 
@@ -105,6 +106,7 @@ public:
 
 	// Solo status accessors.
 	void setSolo(bool bSolo);
+	void setTempoSolo(bool bSolo);
 	bool isSolo() const;
 
 	// Track gain (volume) accessor.
@@ -246,11 +248,13 @@ public:
 	qtractorAudioBufferThread *syncThread();
 
 	// Track state (monitor, record, mute, solo) button setup.
+	qtractorSubject *tempoSubject() const;
 	qtractorSubject *monitorSubject() const;
 	qtractorSubject *recordSubject() const;
 	qtractorSubject *muteSubject() const;
 	qtractorSubject *soloSubject() const;
 
+	qtractorMidiControlObserver *tempoObserver() const;
 	qtractorMidiControlObserver *monitorObserver() const;
 	qtractorMidiControlObserver *recordObserver() const;
 	qtractorMidiControlObserver *muteObserver() const;
@@ -282,6 +286,11 @@ public:
 	// Track automation current curve accessor.
 	void setCurrentCurve(qtractorCurve *pCurrentCurve);
 	qtractorCurve *currentCurve() const;
+
+	// Track tempo curve accessor.
+	void setTrackTempoCurve(qtractorTempoCurve *pTempoCurve);
+	qtractorTempoCurve *trackTempoCurve() const
+		{ return m_pTempoCurve; }
 
 	// Track automation curve serialization methods.
 	static void loadCurveFile(
@@ -393,6 +402,7 @@ private:
 	MidiPanningObserver *m_pMidiPanningObserver;
 
 	// State (monitor, record, mute, solo) observer stuff.
+	qtractorMidiControlObserver *m_pTempoObserver;
 	qtractorMidiControlObserver *m_pMonitorObserver;
 
 	class StateObserver;
@@ -401,6 +411,7 @@ private:
 	StateObserver   *m_pMuteObserver;
 	StateObserver   *m_pSoloObserver;
 
+	qtractorSubject *m_pTempoSubject;
 	qtractorSubject *m_pMonitorSubject;
 	qtractorSubject *m_pRecordSubject;
 	qtractorSubject *m_pMuteSubject;
@@ -409,6 +420,8 @@ private:
 	qtractorMidiControl::Controllers m_controllers;
 
 	qtractorCurveFile *m_pCurveFile;
+
+	qtractorTempoCurve *m_pTempoCurve;
 
 	// Take(record) descriptor/id registry.
 	mutable QHash<int, TakeInfo *> m_idtakes;

--- a/src/qtractorTrackForm.cpp
+++ b/src/qtractorTrackForm.cpp
@@ -24,6 +24,7 @@
 #include "qtractorAbout.h"
 #include "qtractorTrack.h"
 #include "qtractorSession.h"
+#include "qtractorSessionCursor.h"
 #include "qtractorInstrument.h"
 
 #include "qtractorAudioEngine.h"
@@ -214,10 +215,13 @@ qtractorTrackForm::qtractorTrackForm (
 		SLOT(trackIconClicked()));
 	QObject::connect(m_ui.AudioRadioButton,
 		SIGNAL(toggled(bool)),
-		SLOT(trackTypeChanged()));
+		SLOT(trackTypeAudio(bool)));
 	QObject::connect(m_ui.MidiRadioButton,
 		SIGNAL(toggled(bool)),
-		SLOT(trackTypeChanged()));
+		SLOT(trackTypeMidi(bool)));
+	QObject::connect(m_ui.TempoRadioButton,
+		SIGNAL(toggled(bool)),
+		SLOT(trackTypeTempo(bool)));
 	QObject::connect(m_ui.InputBusNameComboBox,
 		SIGNAL(activated(const QString &)),
 		SLOT(inputBusNameChanged(const QString&)));
@@ -324,6 +328,10 @@ void qtractorTrackForm::setTrack ( qtractorTrack *pTrack )
 	m_ui.TrackNameTextEdit->setPlainText(m_props.trackName);
 	qtractorEngine *pEngine = NULL;
 	switch (m_props.trackType) {
+	case qtractorTrack::Tempo:
+		pEngine = (m_pTrack->session())->audioEngine();
+		m_ui.TempoRadioButton->setChecked(true);
+		break;
 	case qtractorTrack::Audio:
 		pEngine = (m_pTrack->session())->audioEngine();
 		m_ui.AudioRadioButton->setChecked(true);
@@ -373,6 +381,7 @@ void qtractorTrackForm::setTrack ( qtractorTrack *pTrack )
 	// Cannot change track type, if track is already chained in session..
 	m_ui.AudioRadioButton->setEnabled(m_props.trackType != qtractorTrack::Midi);
 	m_ui.MidiRadioButton->setEnabled(m_props.trackType != qtractorTrack::Audio);
+	m_ui.TempoRadioButton->setEnabled(m_props.trackType != qtractorTrack::Tempo);
 
 	// A bit of parental control...
 	QObject::connect(pCommands,
@@ -405,15 +414,16 @@ const qtractorTrack::Properties& qtractorTrackForm::properties (void) const
 // Selected track type determinator.
 qtractorTrack::TrackType qtractorTrackForm::trackType (void) const
 {
-	qtractorTrack::TrackType trackType = qtractorTrack::None;
-
 	if (m_ui.AudioRadioButton->isChecked())
-		trackType = qtractorTrack::Audio;
+		return qtractorTrack::Audio;
 	else
 	if (m_ui.MidiRadioButton->isChecked())
-		trackType = qtractorTrack::Midi;
+		return qtractorTrack::Midi;
+	else
+	if (m_ui.TempoRadioButton->isChecked())
+		return qtractorTrack::Tempo;
 
-	return trackType;
+	return qtractorTrack::None;
 }
 
 
@@ -664,8 +674,13 @@ void qtractorTrackForm::updateTrackType ( qtractorTrack::TrackType trackType )
 	qtractorEngine *pEngine = NULL;
 	QIcon icon;
 	switch (trackType) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		pEngine = m_pTrack->session()->audioEngine();
+		if (pEngine) {
+			qtractorSessionCursor *pAudioCursor = pEngine->sessionCursor();
+			pAudioCursor->setSyncType(qtractorTrack::Audio);
+		}
 		icon = QIcon(":/images/trackAudio.png");
 		m_ui.MidiGroupBox->hide();
 		m_ui.MidiGroupBox->setEnabled(false);
@@ -1196,6 +1211,28 @@ void qtractorTrackForm::trackIconClicked (void)
 }
 
 
+// Track type radio-button handlers/filters.
+void qtractorTrackForm::trackTypeAudio (bool enabled)
+{
+	if (enabled)
+		trackTypeChanged();
+}
+
+
+void qtractorTrackForm::trackTypeTempo (bool enabled)
+{
+	if (enabled)
+		trackTypeChanged();
+}
+
+
+void qtractorTrackForm::trackTypeMidi (bool enabled)
+{
+	if (enabled)
+		trackTypeChanged();
+}
+
+
 // Make changes due to track type.
 void qtractorTrackForm::trackTypeChanged (void)
 {
@@ -1257,6 +1294,7 @@ void qtractorTrackForm::outputBusNameChanged ( const QString& sBusName )
 		= qtractorTrackForm::trackType();
 
 	switch (trackType) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio: {
 		// (Re)initialize plugin-list audio output bus properly...
 		const QString& sOutputBusName = m_pTrack->outputBusName();
@@ -1292,6 +1330,7 @@ void qtractorTrackForm::busNameClicked (void)
 	// Depending on track type...
 	qtractorEngine *pEngine = NULL;
 	switch (trackType()) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		pEngine = m_pTrack->session()->audioEngine();
 		break;
@@ -1558,6 +1597,7 @@ void qtractorTrackForm::loadDefaultBusNames (
 	QString sOutputBusName;
 
 	switch (trackType) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		sInputBusName  = g_sAudioInputBusName;;
 		sOutputBusName = g_sAudioOutputBusName;
@@ -1590,6 +1630,7 @@ void qtractorTrackForm::saveDefaultBusNames (
 	const int iOutputBusIndex = m_ui.OutputBusNameComboBox->currentIndex();
 
 	switch (trackType) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		if (iInputBusIndex > 0)
 			g_sAudioInputBusName  = m_ui.InputBusNameComboBox->currentText();

--- a/src/qtractorTrackForm.h
+++ b/src/qtractorTrackForm.h
@@ -70,6 +70,9 @@ protected slots:
 
 	void pluginListChanged();
 
+	void trackTypeAudio(bool enabled);
+	void trackTypeTempo(bool enabled);
+	void trackTypeMidi(bool enabled);
 	void trackTypeChanged();
 	void inputBusNameChanged(const QString& sBusName);
 	void outputBusNameChanged(const QString& sBusName);

--- a/src/qtractorTrackForm.ui
+++ b/src/qtractorTrackForm.ui
@@ -144,6 +144,16 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QRadioButton" name="TempoRadioButton" >
+              <property name="toolTip" >
+               <string>Tempo track type</string>
+              </property>
+              <property name="text" >
+               <string>&amp;Tempo</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/src/qtractorTrackList.cpp
+++ b/src/qtractorTrackList.cpp
@@ -420,9 +420,13 @@ void qtractorTrackList::Item::update ( qtractorTrackList *pTrackList )
 
 	switch (track->trackType()) {
 
+		case qtractorTrack::Tempo:
 		case qtractorTrack::Audio: {
 			// Audio Bus name...
-			text << sBusText + '\n' + QObject::tr("Audio");
+			if (track->trackType() == qtractorTrack::Tempo)
+				text << sBusText + '\n' + QObject::tr("Tempo");
+			else
+				text << sBusText + '\n' + QObject::tr("Audio");
 			// Audio channels...
 			qtractorAudioBus *pAudioBus
 				= static_cast<qtractorAudioBus *> (track->outputBus());
@@ -1086,6 +1090,7 @@ void qtractorTrackList::drawCell (
 		if (iCol == Bus) {
 			const QPixmap *pPixmap = NULL;
 			switch ((pItem->track)->trackType()) {
+			case qtractorTrack::Tempo:
 			case qtractorTrack::Audio:
 				pPixmap = m_pPixmap[IconAudio];
 				break;

--- a/src/qtractorTrackView.cpp
+++ b/src/qtractorTrackView.cpp
@@ -6119,7 +6119,6 @@ void qtractorTrackView::closeEditCurveNode (void)
 						= new qtractorTempoCurveEditCommand(m_pEditTempoCurve);
 					pEditTempoCurveNodeCommand->moveNode(m_pEditTimeScaleNode,
 						fNewTempo, iNewBeatsPerBar, iNewBeatDivisor);
-					pSession->execute(pEditTempoCurveNodeCommand);
 			}
 			// Reset editing references...
 			m_iEditTempoCurveNodeDirty = 0;
@@ -6174,7 +6173,6 @@ void qtractorTrackView::editTempoCurveNodeChanged (void)
 						= new qtractorTempoCurveEditCommand(m_pEditTempoCurve);
 					pEditTempoCurveNodeCommand->moveNode(m_pEditTimeScaleNode,
 						fNewTempo, iNewBeatsPerBar, iNewBeatDivisor);
-					pSession->execute(pEditTempoCurveNodeCommand);
 			}
 			// Reset editing references...
 			m_iEditTempoCurveNodeDirty = 0;

--- a/src/qtractorTrackView.cpp
+++ b/src/qtractorTrackView.cpp
@@ -36,14 +36,18 @@
 #include "qtractorFileListView.h"
 #include "qtractorClipSelect.h"
 #include "qtractorCurveSelect.h"
+#include "qtractorTempoCurveSelect.h"
 
 #include "qtractorOptions.h"
 
 #include "qtractorClipCommand.h"
 #include "qtractorCurveCommand.h"
+#include "qtractorTempoCurveCommand.h"
 
 #include "qtractorMainForm.h"
 #include "qtractorThumbView.h"
+
+#include "qtractorMidiControlObserver.h"
 
 #include <QToolButton>
 #include <QDoubleSpinBox>
@@ -100,6 +104,7 @@ qtractorTrackView::qtractorTrackView ( qtractorTracks *pTracks,
 
 	m_pClipSelect    = new qtractorClipSelect();
 	m_pCurveSelect   = new qtractorCurveSelect();
+	m_pTempoCurveSelect   = new qtractorTempoCurveSelect();
 
 	m_pSessionCursor = NULL;
 	m_pRubberBand    = NULL;
@@ -121,6 +126,11 @@ qtractorTrackView::qtractorTrackView ( qtractorTracks *pTracks,
 	m_pEditCurveNode = NULL;
 	m_pEditCurveNodeSpinBox = NULL;
 	m_iEditCurveNodeDirty = 0;
+
+	m_pEditTempoCurve = NULL;
+	m_pEditTimeScaleNode = NULL;
+	m_pEditTempoCurveNodeSpinBox = NULL;
+	m_iEditTempoCurveNodeDirty = 0;
 
 	clear();
 
@@ -200,6 +210,7 @@ qtractorTrackView::~qtractorTrackView (void)
 	clear();
 
 	delete m_pCurveSelect;
+	delete m_pTempoCurveSelect;
 	delete m_pClipSelect;
 }
 
@@ -211,6 +222,7 @@ void qtractorTrackView::clear (void)
 
 	m_pClipSelect->clear();
 	m_pCurveSelect->clear();
+	m_pTempoCurveSelect->clear();
 
 	m_dropType   = qtractorTrack::None;
 	m_dragState  = DragNone;
@@ -255,6 +267,38 @@ void qtractorTrackView::clear (void)
 	qtractorScrollView::setContentsPos(0, 0);
 }
 
+void qtractorTrackView::trackTempoCurveShow(qtractorSession *pSession, qtractorTrack *pTrack)
+{
+	qtractorSubject *pSubject = NULL;
+//	qtractorCurveList *pCurveList = NULL;
+	qtractorMidiControlObserver *pMidiObserver;
+
+	if (pSession == NULL || pTrack == NULL)
+		return;
+
+	if (pTrack->trackType() != qtractorTrack::Tempo)
+		return;
+
+	pMidiObserver = pTrack->tempoObserver();
+	if (pMidiObserver) {
+		pSubject = pMidiObserver->subject();
+	}
+
+	qtractorTempoCurve *pTempoCurve = NULL;
+	if (pSubject) {
+		pTempoCurve = pSubject->tempoCurve();
+
+		if (pTempoCurve == NULL) {
+			pTempoCurve = new qtractorTempoCurve(pSession->timeScale(), pSubject);
+			if (pTempoCurve != NULL) {
+				pTrack->setTrackTempoCurve(pTempoCurve);
+				pTrack->setCurrentCurve(NULL);
+
+				pSession->execute(new qtractorTempoCurveEditCommand(pTempoCurve));
+			}
+		}
+	}
+}
 
 // Update track view content height.
 void qtractorTrackView::updateContentsHeight (void)
@@ -642,9 +686,11 @@ void qtractorTrackView::drawContents ( QPainter *pPainter, const QRect& rect )
 
 	qtractorTrack *pTrack = pSession->tracks().first();
 	while (pTrack && y2 < ch) {
+		trackTempoCurveShow(pSession, pTrack);
 		y1  = y2;
 		y2 += pTrack->zoomHeight();
 		qtractorCurve *pCurve = pTrack->currentCurve();
+		qtractorTempoCurve *pTempoCurve = pTrack->trackTempoCurve();
 		if (pCurve && y2 > cy) {
 			const int h = y2 - y1 - 2;
 			const QRect trackRect(x, y1 - cy + 1, w, h);
@@ -731,6 +777,70 @@ void qtractorTrackView::drawContents ( QPainter *pPainter, const QRect& rect )
 					= items.constEnd();
 				for ( ; iter != iter_end; ++iter) {
 					qtractorCurveSelect::Item *pItem = iter.value();
+					if (pItem->flags & 1) {
+						QRect rectNode(pItem->rectNode);
+						rectNode.moveTopLeft(contentsToViewport(
+							rectNode.topLeft() + QPoint(m_iDragCurveX, 0)));
+						pPainter->fillRect(rectNode, QColor(0, 0, 255, 80));
+					}
+				}
+			}
+		}
+		else
+		if (pTempoCurve && y2 > cy) {
+			const int h = y2 - y1 - 2;
+			const QRect trackRect(x, y1 - cy + 1, w, h);
+			if (iTrackStart == 0)
+				iTrackStart = pSession->frameFromPixel(cx + x);
+			if (iTrackEnd == 0)
+				iTrackEnd = pSession->frameFromPixel(cx + x + w);
+			unsigned long frame = iTrackStart;
+			qtractorTimeScale::Cursor cursor(pTempoCurve->timeScale());
+			qtractorTimeScale::Node *pNode = cursor.seekFrame(frame);
+			const bool bLocked = pTempoCurve->isLocked();
+			int xc2, xc1 = trackRect.x();
+//			int yc2, yc1 = y2 - int(cursor.scale(pNode, frame) * float(h)) - cy;
+			int yc2, yc1 = y2 - int(pTempoCurve->scale(pNode, frame) * float(h)) - cy;
+			int yc3, xc3 = xc1 + 4;
+			QColor rgbCurve(pTempoCurve->color());
+			QPen pen(rgbCurve);
+			pPainter->setPen(pen);
+			QPainterPath path;
+			path.moveTo(xc1, yc1);
+			while (pNode && pNode->frame < iTrackEnd) {
+				xc2 = pSession->pixelFromFrame(pNode->frame) - cx;
+//				yc2 = y2 - int(cursor.scale(pNode) * float(h)) - cy;
+				yc2 = y2 - int(pTempoCurve->scale(pNode) * float(h)) - cy;
+				if (!bLocked)
+					pPainter->drawRect(QRect(xc2 - 4, yc2 - 4, 8, 8));
+				path.lineTo(xc2, yc1);
+				yc1 = yc2;
+				path.lineTo(xc2, yc2);
+				pNode = pNode->next();
+			}
+			xc2 = rect.right();
+			frame = pSession->frameFromPixel(cx + xc2);
+//			yc2 = y2 - int(cursor.scale(frame) * float(h)) - cy;
+			yc2 = y2 - int(pTempoCurve->scale(frame) * float(h)) - cy;
+			path.lineTo(xc2, yc1);
+			path.lineTo(xc2, yc2);
+			// Draw line...
+			//pen.setWidth(2);
+			pPainter->strokePath(path, pen);	
+			// Fill semi-transparent area...
+			rgbCurve.setAlpha(60);
+			path.lineTo(xc2, y2 - cy);
+			path.lineTo(xc1, y2 - cy);
+			pPainter->fillPath(path, rgbCurve);
+			if (m_bCurveEdit && m_pTempoCurveSelect->isCurrentCurve(pTempoCurve)) {
+				const qtractorTempoCurveSelect::ItemList& items
+					= m_pTempoCurveSelect->items();
+				qtractorTempoCurveSelect::ItemList::ConstIterator iter
+					= items.constBegin();
+				const qtractorTempoCurveSelect::ItemList::ConstIterator iter_end
+					= items.constEnd();
+				for ( ; iter != iter_end; ++iter) {
+					qtractorTempoCurveSelect::Item *pItem = iter.value();
 					if (pItem->flags & 1) {
 						QRect rectNode(pItem->rectNode);
 						rectNode.moveTopLeft(contentsToViewport(
@@ -1167,11 +1277,64 @@ qtractorCurve::Node *qtractorTrackView::nodeAtTrack ( const QPoint& pos,
 }
 
 
+// Get tempo curve node from given contents position.
+qtractorTimeScale::Node *qtractorTrackView::tempoNodeAtTrack ( const QPoint& pos,
+	qtractorTrack *pTrack, TrackViewInfo *pTrackViewInfo ) const
+{
+	if (pTrack == NULL)
+		return NULL;
+
+	qtractorSession *pSession = pTrack->session();
+	if (pSession == NULL || m_pSessionCursor == NULL)
+		return NULL;
+
+	qtractorTempoCurve *pTempoCurve = pTrack->trackTempoCurve();
+	if (pTempoCurve == NULL)
+		return NULL;
+
+	const int w  = pTrackViewInfo->trackRect.width();
+	const int h  = pTrackViewInfo->trackRect.height();
+	const int y2 = pTrackViewInfo->trackRect.bottom() + 1;
+	const int cx = qtractorScrollView::contentsX();
+
+	qtractorTimeScale::Node *pNode = pTempoCurve->timeScale()->nodes().first();
+	qtractorTimeScale::Node *pNode_next;
+
+	while (pNode) {
+		pNode_next = pNode->next();
+		if (pNode_next == NULL)
+			break;
+
+		const int x1 = pSession->pixelFromFrame(pNode->frame);
+		const int x2 = pSession->pixelFromFrame(pNode_next->frame);
+		if (x1 < cx) {
+			if (QRect(cx, (y2 - h), (x2 - cx), h).contains(pos))
+				break;
+		} else {
+			if (QRect((x1 - cx), (y2 - h), (x2 - x1 + cx), h).contains(pos))
+				break;
+		}
+		// Test next...
+		pNode = pNode->next();
+	}
+
+	return pNode;
+}
+
+
 qtractorCurve::Node *qtractorTrackView::nodeAt ( const QPoint& pos ) const
 {
 	TrackViewInfo tvi;
 	qtractorTrack *pTrack = trackAt(pos, false, &tvi);
 	return nodeAtTrack(pos, pTrack, &tvi);
+}
+
+
+qtractorTimeScale::Node *qtractorTrackView::tempoNodeAt ( const QPoint& pos ) const
+{
+	TrackViewInfo tvi;
+	qtractorTrack *pTrack = trackAt(pos, false, &tvi);
+	return tempoNodeAtTrack(pos, pTrack, &tvi);
 }
 
 
@@ -1410,7 +1573,7 @@ qtractorTrack *qtractorTrackView::dragClipDrop (
 		}
 		// Then as an Audio file ?
 		if (m_dropType == qtractorTrack::None
-			|| m_dropType == qtractorTrack::Audio) {
+			|| m_dropType == qtractorTrack::Audio || m_dropType == qtractorTrack::Tempo) {
 			qtractorAudioFile *pFile
 				= qtractorAudioFileFactory::createAudioFile(pDropItem->path);
 			if (pFile) {
@@ -1427,13 +1590,13 @@ qtractorTrack *qtractorTrackView::dragClipDrop (
 					m_rectDrag.translate(0, m_rectDrag.height() + 4);
 					if (m_dropType == qtractorTrack::None)
 						m_dropType = qtractorTrack::Audio;
-				} else if (m_dropType == qtractorTrack::Audio) {
+				} else if ((m_dropType == qtractorTrack::Audio) || (m_dropType == qtractorTrack::Tempo)) {
 					iter.remove();
 					delete pDropItem;
 				}
 				delete pFile;
 				continue;
-			} else if (m_dropType == qtractorTrack::Audio) {
+			} else if ((m_dropType == qtractorTrack::Audio) || (m_dropType == qtractorTrack::Tempo)) {
 				iter.remove();
 				delete pDropItem;
 			}
@@ -1625,6 +1788,7 @@ bool qtractorTrackView::dropClip (
 			// Depending on import type...
 			if (!files.isEmpty()) {
 				switch (m_dropType) {
+				case qtractorTrack::Tempo:
 				case qtractorTrack::Audio:
 					m_pTracks->addAudioTracks(files, iClipStart);
 					++iAddTrack;
@@ -1675,6 +1839,7 @@ bool qtractorTrackView::dropClip (
 	while (iter.hasNext()) {
 		DropItem *pDropItem = iter.next();
 		switch (pTrack->trackType()) {
+		case qtractorTrack::Tempo:
 		case qtractorTrack::Audio: {
 			qtractorAudioClip *pAudioClip = new qtractorAudioClip(pTrack);
 			if (pAudioClip) {
@@ -1788,11 +1953,17 @@ void qtractorTrackView::mousePressEvent ( QMouseEvent *pMouseEvent )
 			|| (m_bCurveEdit && m_dragCursor == DragNone)) {
 			TrackViewInfo tvi;
 			qtractorTrack *pTrack = trackAt(pos, true, &tvi);
-			if (pTrack && m_dragCursor == DragCurveNode) {
+			if (pTrack && pTrack->currentCurve() && m_dragCursor == DragCurveNode) {
 				qtractorCurve::Node *pNode = nodeAtTrack(pos, pTrack, &tvi);
 				if (pNode) {
 					m_pDragCurve = pTrack->currentCurve();
 					m_pDragCurveNode = pNode;
+				}
+			} else if (pTrack && pTrack->trackTempoCurve() && m_dragCursor == DragCurveNode) {
+				qtractorTimeScale::Node *pNode = tempoNodeAtTrack(pos, pTrack, &tvi);
+				if (pNode) {
+					m_pDragTempoCurve = pTrack->trackTempoCurve();
+					m_pDragTimeScaleNode = pNode;
 				}
 			}
 		}
@@ -2137,6 +2308,11 @@ void qtractorTrackView::mouseReleaseEvent ( QMouseEvent *pMouseEvent )
 		case DragClipDrop:
 		case DragNone:
 		default:
+			TrackViewInfo tvi;
+			qtractorTrack *pTrack = trackAt(pos, true, &tvi);
+			if (pTrack && pTrack->trackTempoCurve()) {
+				qtractorTimeScale::Node *pNode = tempoNodeAtTrack(pos, pTrack, &tvi);
+			}
 			break;
 		}
 	}
@@ -2155,10 +2331,16 @@ void qtractorTrackView::mouseDoubleClickEvent ( QMouseEvent *pMouseEvent )
 
 	TrackViewInfo tvi;
 	qtractorTrack *pTrack = trackAt(pos, true, &tvi);
-	if (pTrack) {
+	if (pTrack && pTrack->currentCurve()) {
 		qtractorCurve::Node *pNode = nodeAtTrack(pos, pTrack, &tvi);
 		if (pNode) {
 			openEditCurveNode(pTrack->currentCurve(), pNode);
+			return;
+		}
+	} else if (pTrack && pTrack->trackTempoCurve()) {
+		qtractorTimeScale::Node *pNode = tempoNodeAtTrack(pos, pTrack, &tvi);
+		if (pNode) {
+			openEditCurveNode(pTrack->trackTempoCurve(), pNode);
 			return;
 		}
 	}
@@ -2215,7 +2397,7 @@ bool qtractorTrackView::eventFilter ( QObject *pObject, QEvent *pEvent )
 					= qtractorScrollView::viewportToContents(pHelpEvent->pos());
 				TrackViewInfo tvi;
 				qtractorTrack *pTrack = trackAt(pos, false, &tvi);
-				if (pTrack) {
+				if (pTrack && pTrack->currentCurve()) {
 					qtractorCurve::Node *pNode = nodeAtTrack(pos, pTrack, &tvi);
 					if (pNode) {
 						qtractorCurve *pCurve = pTrack->currentCurve();
@@ -2223,6 +2405,16 @@ bool qtractorTrackView::eventFilter ( QObject *pObject, QEvent *pEvent )
 							nodeToolTip(pCurve, pNode), pViewport);
 						return true;
 					}
+				} else if (pTrack && pTrack->trackTempoCurve()) {
+					qtractorTimeScale::Node *pNode = tempoNodeAtTrack(pos, pTrack, &tvi);
+					if (pNode) {
+						qtractorTempoCurve *pTempoCurve = pTrack->trackTempoCurve();
+						QToolTip::showText(pHelpEvent->globalPos(),
+							nodeToolTip(pTempoCurve, pNode), pViewport);
+						return true;
+					}
+				}
+				if (pTrack) {
 					qtractorClip *pClip = clipAtTrack(pos, NULL, pTrack, &tvi);
 					if (pClip) {
 						QToolTip::showText(pHelpEvent->globalPos(),
@@ -2292,6 +2484,7 @@ void qtractorTrackView::selectClipFile ( bool bReset )
 		return;
 
 	switch (pTrack->trackType()) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio: {
 		qtractorAudioClip *pAudioClip
 			= static_cast<qtractorAudioClip *> (m_pClipDrag);
@@ -3632,7 +3825,7 @@ void qtractorTrackView::dragClipResizeDrop (
 	float fTimeStretch = 0.0f;
 	if (bTimeStretch && m_pClipDrag->track()) {
 		float fOldTimeStretch = 1.0f;
-		if ((m_pClipDrag->track())->trackType() == qtractorTrack::Audio) {
+		if (((m_pClipDrag->track())->trackType() == qtractorTrack::Audio) || ((m_pClipDrag->track())->trackType() == qtractorTrack::Tempo)) {
 			qtractorAudioClip *pAudioClip
 				= static_cast<qtractorAudioClip *> (m_pClipDrag);
 			if (pAudioClip)
@@ -3936,6 +4129,34 @@ QString qtractorTrackView::nodeToolTip (
 				.arg(pNode->value);
 			if (pCurve) {
 				qtractorSubject *pSubject = pCurve->subject();
+				if (pSubject) {
+					sToolTip = QString("%1\n%2")
+						.arg(pSubject->name())
+						.arg(sToolTip);
+				}
+			}
+		}
+	}
+
+	return sToolTip;
+}
+
+
+// Common tool-tip builder for tempo nodes.
+QString qtractorTrackView::nodeToolTip (
+	qtractorTempoCurve *pTempoCurve, qtractorTimeScale::Node *pNode) const
+{
+	QString sToolTip;
+
+	qtractorSession *pSession = qtractorSession::getInstance();
+	if (pSession) {
+		qtractorTimeScale *pTimeScale = pSession->timeScale();
+		if (pTimeScale) {
+			sToolTip = QString("(%2, %3)")
+				.arg(pTimeScale->textFromFrame(pNode->frame))
+				.arg(pNode->tempo);
+			if (pTempoCurve) {
+				qtractorSubject *pSubject = pTempoCurve->subject();
 				if (pSubject) {
 					sToolTip = QString("%1\n%2")
 						.arg(pSubject->name())
@@ -4569,6 +4790,13 @@ void qtractorTrackView::ClipBoard::addNode ( qtractorCurve::Node *pNode,
 }
 
 
+void qtractorTrackView::ClipBoard::addNode ( qtractorTimeScale::Node *pNode,
+	const QRect& nodeRect, unsigned long iFrame, float fValue )
+{
+	nodes.append(new NodeItem(pNode, nodeRect, iFrame, fValue));
+}
+
+
 // Clipboard reset method.
 void qtractorTrackView::ClipBoard::clear (void)
 {
@@ -4971,6 +5199,7 @@ void qtractorTrackView::pasteClipboard (
 	// maybe we can only do it over the original...
 	TrackViewInfo tvi;
 	qtractorCurve *pCurve = NULL;
+	qtractorTempoCurve *pTempoCurve = NULL;
 	if (m_bCurveEdit) {
 		if (g_clipboard.nodes.isEmpty())
 			return;
@@ -4980,9 +5209,10 @@ void qtractorTrackView::pasteClipboard (
 		if (pTrack == NULL)
 			return;
 		pCurve = pTrack->currentCurve();
-		if (pCurve == NULL)
+		pTempoCurve = pTrack->trackTempoCurve();
+		if (pCurve == NULL && pTempoCurve)
 			return;
-		if (pCurve->isLocked())
+		if (pCurve && pCurve->isLocked())
 			return;
 	}
 	else
@@ -4992,6 +5222,7 @@ void qtractorTrackView::pasteClipboard (
 	// Reset any current selection, whatsoever...
 	m_pClipSelect->reset();
 	m_pCurveSelect->clear();
+	m_pTempoCurveSelect->clear();
 
 	resetDragState();
 
@@ -5008,29 +5239,55 @@ void qtractorTrackView::pasteClipboard (
 	if (m_bCurveEdit) {
 		// Flag this as target current curve,
 		// otherwise nothing will be displayed...
-		m_pCurveSelect->setCurve(pCurve);
-		const int h = tvi.trackRect.height();
-		const int y2 = tvi.trackRect.bottom() + 1;
-		QListIterator<NodeItem *> iter(g_clipboard.nodes);
-		for (unsigned short i = 0; i < m_iPasteCount; ++i) {
-			iter.toFront();
-			while (iter.hasNext()) {
-				NodeItem *pNodeItem = iter.next();
-				const int x
-					= pSession->pixelFromFrame(pNodeItem->frame + iPasteDelta);
-				const float s = pCurve->scaleFromValue(pNodeItem->value);
-				const int y = y2 - int(s * float(h));
-				m_pCurveSelect->addItem(pNodeItem->node,
-					QRect(x - 4, y - 4, 8, 8));
+		if (pCurve) {
+			m_pCurveSelect->setCurve(pCurve);
+			const int h = tvi.trackRect.height();
+			const int y2 = tvi.trackRect.bottom() + 1;
+			QListIterator<NodeItem *> iter(g_clipboard.nodes);
+			for (unsigned short i = 0; i < m_iPasteCount; ++i) {
+				iter.toFront();
+				while (iter.hasNext()) {
+					NodeItem *pNodeItem = iter.next();
+					const int x
+						= pSession->pixelFromFrame(pNodeItem->frame + iPasteDelta);
+					const float s = pCurve->scaleFromValue(pNodeItem->value);
+					const int y = y2 - int(s * float(h));
+					m_pCurveSelect->addItem(pNodeItem->node,
+						QRect(x - 4, y - 4, 8, 8));
+				}
+				iPasteDelta += m_iPastePeriod;
 			}
-			iPasteDelta += m_iPastePeriod;
+			m_pCurveSelect->update(true);
+			// We'll start a brand new floating state...
+			m_dragState = m_dragCursor = DragCurvePaste;
+			m_rectDrag  = m_pCurveSelect->rect();
+			m_posDrag   = m_rectDrag.topLeft();
+			m_posStep   = QPoint(0, 0);
+		} else if (pTempoCurve) {
+			m_pTempoCurveSelect->setTempoCurve(pTempoCurve);
+			const int h = tvi.trackRect.height();
+			const int y2 = tvi.trackRect.bottom() + 1;
+			QListIterator<NodeItem *> iter(g_clipboard.nodes);
+			for (unsigned short i = 0; i < m_iPasteCount; ++i) {
+				iter.toFront();
+				while (iter.hasNext()) {
+					NodeItem *pNodeItem = iter.next();
+					const int x
+						= pSession->pixelFromFrame(pNodeItem->frame + iPasteDelta);
+					const float s = pTempoCurve->scaleFromValue(pNodeItem->value);
+					const int y = y2 - int(s * float(h));
+					m_pTempoCurveSelect->addItem((qtractorTimeScale::Node *)pNodeItem->node,
+						QRect(x - 4, y - 4, 8, 8));
+				}
+				iPasteDelta += m_iPastePeriod;
+			}
+			m_pTempoCurveSelect->update(true);
+			// We'll start a brand new floating state...
+			m_dragState = m_dragCursor = DragCurvePaste;
+			m_rectDrag  = m_pTempoCurveSelect->rect();
+			m_posDrag   = m_rectDrag.topLeft();
+			m_posStep   = QPoint(0, 0);
 		}
-		m_pCurveSelect->update(true);
-		// We'll start a brand new floating state...
-		m_dragState = m_dragCursor = DragCurvePaste;
-		m_rectDrag  = m_pCurveSelect->rect();
-		m_posDrag   = m_rectDrag.topLeft();
-		m_posStep   = QPoint(0, 0);
 	} else {
 		// Copy clipboard items to floating selection;
 		// adjust clip widths/lengths just in case time
@@ -5522,6 +5779,7 @@ qtractorClip *qtractorTrackView::cloneClip ( qtractorClip *pClip )
 
 	qtractorClip *pNewClip = NULL;
 	switch (pTrack->trackType()) {
+		case qtractorTrack::Tempo:
 		case qtractorTrack::Audio: {
 			qtractorAudioClip *pAudioClip
 				= static_cast<qtractorAudioClip *> (pClip);
@@ -5718,44 +5976,165 @@ void qtractorTrackView::openEditCurveNode (
 }
 
 
+// Tempo/curve node editor methods.
+void qtractorTrackView::openEditCurveNode (
+	qtractorTempoCurve *pTempoCurve, qtractorTimeScale::Node *pNode )
+{
+	closeEditCurveNode();
+
+	if (pTempoCurve == NULL || pNode == NULL)
+		return;
+
+	qtractorSubject *pSubject = pTempoCurve->subject();
+	if (pSubject == NULL)
+		return;
+
+#ifdef CONFIG_DEBUG
+	qDebug("qtractorTrackView::openEditTempoCurveNode(%p, %p)", pTempoCurve, pNode);
+#endif
+
+	m_pEditTempoCurve = pTempoCurve;
+	m_pEditTimeScaleNode = pNode;
+
+	const float fMaxValue = pSubject->maxValue();
+	const float fMinValue = pSubject->minValue();
+
+	int iDecimals = 0;
+	if (pSubject->isDecimal()) {
+		const float fDecs
+			= ::log10f(fMaxValue - fMinValue);
+		if (fDecs < 0.0f)
+			iDecimals = 6;
+		else if (fDecs < 3.0f)
+			iDecimals = 3;
+		else if (fDecs < 6.0f)
+			iDecimals = 1;
+	#if 0
+		if (m_pEditTempoCurve->isLogarithmic())
+			++iDecimals;
+	#endif
+	}
+
+	// Tempo spin-box.
+	const QSize  pad(4, 0);
+	const QFont& font0 = qtractorScrollView::font();
+	const QFont  font(font0.family(), font0.pointSize() + 2);
+	const QFontMetrics fm(font);
+	const int d = fm.height() + fm.leading() + 8;
+	const QString sTempo("999.9 9/9");
+	m_pEditTempoCurveNodeSpinBox = new qtractorTempoSpinBox(this);
+	m_pEditTempoCurveNodeSpinBox->setTempo(pNode->tempo, false);
+	m_pEditTempoCurveNodeSpinBox->setBeatsPerBar(pNode->beatsPerBar, false);
+	m_pEditTempoCurveNodeSpinBox->setBeatDivisor(pNode->beatDivisor, false);
+	m_pEditTempoCurveNodeSpinBox->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+	m_pEditTempoCurveNodeSpinBox->setMinimumSize(QSize(fm.width(sTempo) + d, d) + pad);
+	m_pEditTempoCurveNodeSpinBox->setToolTip(tr("Curve tempo (BPM)"));
+	m_pEditTempoCurveNodeSpinBox->setContextMenuPolicy(Qt::CustomContextMenu);
+	m_pEditTempoCurveNodeSpinBox->setAccelerated(true);
+//	m_pEditTempoCurveNodeSpinBox->setToolTip(pSubject->name());
+//	m_pEditTempoCurveNodeSpinBox->setMinimumWidth(42);
+
+	QWidget *pViewport = qtractorScrollView::viewport();
+	const int w = pViewport->width();
+	const int h = pViewport->height();
+	const QPoint& vpos = pViewport->mapFromGlobal(QCursor::pos());
+	const QSize& size = m_pEditTempoCurveNodeSpinBox->sizeHint();
+	int x = vpos.x() + 4;
+	int y = vpos.y();
+	if (x +  size.width()  > w)
+		x -= size.width()  + 8;
+	if (y +  size.height() > h)
+		y -= size.height();
+	m_pEditTempoCurveNodeSpinBox->move(x, y);
+	m_pEditTempoCurveNodeSpinBox->show();
+
+	m_pEditTempoCurveNodeSpinBox->setFocus();
+
+	QObject::connect(m_pEditTempoCurveNodeSpinBox,
+		SIGNAL(valueChanged(float, unsigned short, unsigned short)),
+		SLOT(editTempoCurveNodeChanged()));
+	QObject::connect(m_pEditTempoCurveNodeSpinBox,
+		SIGNAL(editingFinished()),
+		SLOT(editTempoCurveNodeFinished()));
+
+	// We'll start clean...
+	m_iEditTempoCurveNodeDirty = 0;
+
+	setSyncViewHoldOn(true);
+}
+
+
 void qtractorTrackView::closeEditCurveNode (void)
 {
-	if (m_pEditCurveNodeSpinBox == NULL)
+	if (m_pEditCurveNodeSpinBox == NULL && m_pEditTempoCurveNodeSpinBox == NULL)
 		return;
 
 #ifdef CONFIG_DEBUG
 	qDebug("qtractorTrackView::closeEditCurveNode()");
 #endif
 
-	// Have we changed anything?
-	if (m_iEditCurveNodeDirty > 0 && m_pEditCurveNode && m_pEditCurve) {
-		// Make it an undoable command...
-		qtractorSession *pSession = qtractorSession::getInstance();
-		if (pSession) {
-			const float fOldValue = m_pEditCurveNode->value;
-			const float fNewValue = m_pEditCurveNodeSpinBox->value();
-			if (::fabsf(fNewValue - fOldValue)
-				> float(m_pEditCurveNodeSpinBox->singleStep())) {
-				qtractorCurveEditCommand *pEditCurveNodeCommand
-					= new qtractorCurveEditCommand(m_pEditCurve);
-				pEditCurveNodeCommand->moveNode(m_pEditCurveNode,
-					m_pEditCurveNode->frame, fNewValue);
-				pSession->execute(pEditCurveNodeCommand);
+	if (m_pEditCurveNodeSpinBox != NULL) {
+		// Have we changed anything?
+		if (m_iEditCurveNodeDirty > 0 && m_pEditCurveNode && m_pEditCurve) {
+			// Make it an undoable command...
+			qtractorSession *pSession = qtractorSession::getInstance();
+			if (pSession) {
+				const float fOldValue = m_pEditCurveNode->value;
+				const float fNewValue = m_pEditCurveNodeSpinBox->value();
+				if (::fabsf(fNewValue - fOldValue)
+					> float(m_pEditCurveNodeSpinBox->singleStep())) {
+					qtractorCurveEditCommand *pEditCurveNodeCommand
+						= new qtractorCurveEditCommand(m_pEditCurve);
+					pEditCurveNodeCommand->moveNode(m_pEditCurveNode,
+						m_pEditCurveNode->frame, fNewValue);
+					pSession->execute(pEditCurveNodeCommand);
+				}
 			}
+			// Reset editing references...
+			m_iEditCurveNodeDirty = 0;
+			m_pEditCurveNode = NULL;
+			m_pEditCurve = NULL;
 		}
-		// Reset editing references...
-		m_iEditCurveNodeDirty = 0;
-		m_pEditCurveNode = NULL;
-		m_pEditCurve = NULL;
+
+		// Time to close...
+		m_pEditCurveNodeSpinBox->blockSignals(true);
+		m_pEditCurveNodeSpinBox->clearFocus();
+		m_pEditCurveNodeSpinBox->close();
+
+		m_pEditCurveNodeSpinBox->deleteLater();
+		m_pEditCurveNodeSpinBox = NULL;
 	}
+	else
+	if (m_pEditTempoCurveNodeSpinBox != NULL) {
+		// Have we changed anything?
+		if (m_iEditTempoCurveNodeDirty > 0 && m_pEditTimeScaleNode && m_pEditTempoCurve) {
+			// Make it an undoable command...
+			qtractorSession *pSession = qtractorSession::getInstance();
+			if (pSession) {
+				const float fOldTempo = m_pEditTimeScaleNode->tempo;
+				const float fNewTempo = m_pEditTempoCurveNodeSpinBox->tempo();
+				const unsigned short iNewBeatsPerBar = m_pEditTempoCurveNodeSpinBox->beatsPerBar();
+				const unsigned short iNewBeatDivisor = m_pEditTempoCurveNodeSpinBox->beatDivisor();
+					qtractorTempoCurveEditCommand *pEditTempoCurveNodeCommand
+						= new qtractorTempoCurveEditCommand(m_pEditTempoCurve);
+					pEditTempoCurveNodeCommand->moveNode(m_pEditTimeScaleNode,
+						fNewTempo, iNewBeatsPerBar, iNewBeatDivisor);
+					pSession->execute(pEditTempoCurveNodeCommand);
+			}
+			// Reset editing references...
+			m_iEditTempoCurveNodeDirty = 0;
+			m_pEditTimeScaleNode = NULL;
+			m_pEditTempoCurve = NULL;
+		}
 
-	// Time to close...
-	m_pEditCurveNodeSpinBox->blockSignals(true);
-	m_pEditCurveNodeSpinBox->clearFocus();
-	m_pEditCurveNodeSpinBox->close();
+		// Time to close...
+		m_pEditTempoCurveNodeSpinBox->blockSignals(true);
+		m_pEditTempoCurveNodeSpinBox->clearFocus();
+		m_pEditTempoCurveNodeSpinBox->close();
 
-	m_pEditCurveNodeSpinBox->deleteLater();
-	m_pEditCurveNodeSpinBox = NULL;
+		m_pEditTempoCurveNodeSpinBox->deleteLater();
+		m_pEditTempoCurveNodeSpinBox = NULL;
+	}
 
 	qtractorScrollView::setFocus();
 }
@@ -5774,10 +6153,50 @@ void qtractorTrackView::editCurveNodeChanged (void)
 }
 
 
+void qtractorTrackView::editTempoCurveNodeChanged (void)
+{
+#ifdef CONFIG_DEBUG_0
+	qDebug("qtractorTrackView::editTempoCurveNodeChanged()");
+#endif
+
+	if (m_pEditTempoCurveNodeSpinBox && m_pEditTimeScaleNode && m_pEditTempoCurve) {
+		++m_iEditTempoCurveNodeDirty;
+		setSyncViewHoldOn(true);
+		if (m_iEditTempoCurveNodeDirty > 0 && m_pEditTimeScaleNode && m_pEditTempoCurve) {
+			// Make it an undoable command...
+			qtractorSession *pSession = qtractorSession::getInstance();
+			if (pSession) {
+				const float fOldTempo = m_pEditTimeScaleNode->tempo;
+				const float fNewTempo = m_pEditTempoCurveNodeSpinBox->tempo();
+				const unsigned short iNewBeatsPerBar = m_pEditTempoCurveNodeSpinBox->beatsPerBar();
+				const unsigned short iNewBeatDivisor = m_pEditTempoCurveNodeSpinBox->beatDivisor();
+					qtractorTempoCurveEditCommand *pEditTempoCurveNodeCommand
+						= new qtractorTempoCurveEditCommand(m_pEditTempoCurve);
+					pEditTempoCurveNodeCommand->moveNode(m_pEditTimeScaleNode,
+						fNewTempo, iNewBeatsPerBar, iNewBeatDivisor);
+					pSession->execute(pEditTempoCurveNodeCommand);
+			}
+			// Reset editing references...
+			m_iEditTempoCurveNodeDirty = 0;
+		}
+	}
+}
+
+
 void qtractorTrackView::editCurveNodeFinished (void)
 {
 #ifdef CONFIG_DEBUG_0
 	qDebug("qtractorTrackView::editCurveNodeFinished()");
+#endif
+
+	closeEditCurveNode();
+}
+
+
+void qtractorTrackView::editTempoCurveNodeFinished (void)
+{
+#ifdef CONFIG_DEBUG_0
+	qDebug("qtractorTrackView::editTempoCurveNodeFinished()");
 #endif
 
 	closeEditCurveNode();

--- a/src/qtractorTrackView.h
+++ b/src/qtractorTrackView.h
@@ -27,6 +27,8 @@
 
 #include "qtractorTrack.h"
 #include "qtractorCurve.h"
+#include "qtractorTempoCurve.h"
+#include "qtractorSpinBox.h"
 
 #include <QPixmap>
 #include <QBrush>
@@ -36,11 +38,13 @@
 class qtractorTracks;
 class qtractorClipSelect;
 class qtractorCurveSelect;
+class qtractorTempoCurveSelect;
 class qtractorMidiSequence;
 class qtractorSessionCursor;
 class qtractorTrackListItem;
 
 class qtractorCurveEditCommand;
+class qtractorTempoCurveEditCommand;
 
 class QToolButton;
 class QDoubleSpinBox;
@@ -73,6 +77,8 @@ public:
 
 	// Track view state reset.
 	void clear();
+
+	void trackTempoCurveShow(qtractorSession *pSession, qtractorTrack *pTrack);
 
 	// Update track view content height.
 	void updateContentsHeight();
@@ -280,6 +286,11 @@ protected:
 		qtractorTrack *pTrack, TrackViewInfo *pTrackViewInfo) const;
 	qtractorCurve::Node *nodeAt(const QPoint& pos) const;
 
+	// Get tempo curve time-scale node from given contents position.
+	qtractorTimeScale::Node *tempoNodeAtTrack(const QPoint& pos,
+		qtractorTrack *pTrack, TrackViewInfo *pTrackViewInfo) const;
+	qtractorTimeScale::Node *tempoNodeAt(const QPoint& pos) const;
+
 	// Get contents visible rectangle from given track.
 	bool trackInfo(qtractorTrack *pTrack,
 		TrackViewInfo *pTrackViewInfo) const;
@@ -380,6 +391,7 @@ protected:
 
 	// Common tool-tip builder for automation nodes.
 	QString nodeToolTip(qtractorCurve *pCurve, qtractorCurve::Node *pNode) const;
+	QString nodeToolTip(qtractorTempoCurve *pCurve, qtractorTimeScale::Node *pNode) const;
 
 	// Reset drag/select/move state.
 	void resetDragState();
@@ -393,8 +405,9 @@ protected:
 	// Vertical line positioning.
 	void drawPositionX(int& iPositionX, int x, bool bSyncView = false);
 
-	// Automation/curve node editor methods.
+	// Automation/Tempo/curve node editor methods.
 	void openEditCurveNode(qtractorCurve *pCurve, qtractorCurve::Node *pNode);
+	void openEditCurveNode(qtractorTempoCurve *pCurve, qtractorTimeScale::Node *pNode);
 	void closeEditCurveNode();
 
 protected slots:
@@ -411,6 +424,10 @@ protected slots:
 	// Automatio/curve node editor slots.
 	void editCurveNodeChanged();
 	void editCurveNodeFinished();
+
+	// Tempo/curve node editor slots.
+	void editTempoCurveNodeChanged();
+	void editTempoCurveNodeFinished();
 
 private:
 
@@ -477,6 +494,7 @@ private:
 	qtractorRubberBand  *m_pRubberBand;
 	qtractorClipSelect  *m_pClipSelect;
 	qtractorCurveSelect *m_pCurveSelect;
+	qtractorTempoCurveSelect *m_pTempoCurveSelect;
 
 	// The clip select mode.
 	SelectMode m_selectMode;
@@ -520,8 +538,12 @@ private:
 		NodeItem(qtractorCurve::Node *pNode, const QRect& nodeRect,
 			unsigned long iFrame, float fValue)
 			: node(pNode), rect(nodeRect), frame(iFrame), value(fValue) {}
+		NodeItem(qtractorTimeScale::Node *pNode, const QRect& nodeRect,
+			unsigned long iFrame, float fValue)
+			: tempoNode(pNode), rect(nodeRect), frame(iFrame), value(fValue) {}
 		// Clipboard item members.
 		qtractorCurve::Node *node;
+		qtractorTimeScale::Node *tempoNode;
 		QRect rect;
 		unsigned long frame;
 		float value;
@@ -539,6 +561,8 @@ private:
 			unsigned long iClipStart, unsigned long iClipOffset,
 			unsigned long iClipLength);
 		void addNode(qtractorCurve::Node *pNode, const QRect& nodeRect,
+			unsigned long iFrame, float fValue);
+		void addNode(qtractorTimeScale::Node *pNode, const QRect& nodeRect,
 			unsigned long iFrame, float fValue);
 		// Clipboard reset method.
 		void clear();
@@ -573,9 +597,15 @@ private:
 	qtractorCurve       *m_pDragCurve;
 	qtractorCurve::Node *m_pDragCurveNode;
 
+	// Tempo curve editing node.
+	qtractorTempoCurve       *m_pDragTempoCurve;
+	qtractorTimeScale::Node  *m_pDragTimeScaleNode;
+
 	int m_iDragCurveX;
 
 	qtractorCurveEditCommand *m_pCurveEditCommand;
+
+	qtractorTempoCurveEditCommand *m_pTempoCurveEditCommand;
 
 	// Temporary sync-view/follow-playhead hold state.
 	bool m_bSyncViewHold;
@@ -586,6 +616,12 @@ private:
 	qtractorCurve::Node *m_pEditCurveNode;
 	QDoubleSpinBox      *m_pEditCurveNodeSpinBox;
 	int                  m_iEditCurveNodeDirty;
+
+	// Tempo curve node editor widget.
+	qtractorTempoCurve       *m_pEditTempoCurve;
+	qtractorTimeScale::Node  *m_pEditTimeScaleNode;
+	qtractorTempoSpinBox *m_pEditTempoCurveNodeSpinBox;
+	int                  m_iEditTempoCurveNodeDirty;
 
 	// Optional edge-shadow gradient brushes.
 	QBrush m_gradLeft;

--- a/src/qtractorTracks.cpp
+++ b/src/qtractorTracks.cpp
@@ -463,6 +463,7 @@ bool qtractorTracks::newClip (void)
 	// Create the clip prototype...
 	qtractorClip *pClip = NULL;
 	switch (pTrack->trackType()) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		pClip = new qtractorAudioClip(pTrack);
 		break;
@@ -777,7 +778,7 @@ bool qtractorTracks::normalizeClipCommand (
 	// Default non-normalized setting...
 	float fGain = pClip->clipGain();
 
-	if (pTrack->trackType() == qtractorTrack::Audio) {
+	if ((pTrack->trackType() == qtractorTrack::Audio) || (pTrack->trackType() == qtractorTrack::Tempo)) {
 		// Normalize audio clip...
 		qtractorAudioClip *pAudioClip
 			= static_cast<qtractorAudioClip *> (pClip);
@@ -988,6 +989,7 @@ bool qtractorTracks::importClips (
 		// This is one of the selected filenames....
 		const QString& sPath = iter.next();
 		switch (pTrack->trackType()) {
+		case qtractorTrack::Tempo:
 		case qtractorTrack::Audio: {
 			// Add the audio clip at once...
 			qtractorAudioClip *pAudioClip = new qtractorAudioClip(pTrack);
@@ -1113,6 +1115,7 @@ bool qtractorTracks::mergeExportClips ( qtractorClipCommand *pClipCommand )
 	// Dispatch to specialized method...
 	bool bResult = false;
 	switch (pTrack->trackType()) {
+	case qtractorTrack::Tempo:
 	case qtractorTrack::Audio:
 		bResult = mergeExportAudioClips(pClipCommand);
 		break;

--- a/src/src.pro
+++ b/src/src.pro
@@ -105,6 +105,9 @@ HEADERS += config.h \
 	qtractorSessionCursor.h \
 	qtractorSessionDocument.h \
 	qtractorSpinBox.h \
+	qtractorTempoCurve.h \
+	qtractorTempoCurveCommand.h \
+	qtractorTempoCurveSelect.h \
 	qtractorThumbView.h \
 	qtractorTimeScale.h \
 	qtractorTimeScaleCommand.h \
@@ -228,6 +231,9 @@ SOURCES += \
 	qtractorSessionCursor.cpp \
 	qtractorSessionDocument.cpp \
 	qtractorSpinBox.cpp \
+	qtractorTempoCurve.cpp \
+	qtractorTempoCurveCommand.cpp \
+	qtractorTempoCurveSelect.cpp \
 	qtractorThumbView.cpp \
 	qtractorTimeScale.cpp \
 	qtractorTimeScaleCommand.cpp \


### PR DESCRIPTION
A tempo-track is an audio-track associated with its own "tempo-map".
Basic usage scenarios:
1. To attach and adjust metronome tempo over existing dynamic-tempo audio
   recordings to assist in subsequent recording or rehearsing sessions.
2. To initially prepare a dynamic tempo base of new recordings (songs).

"tempo-tracks" functionality consists of the following properties:
- A tempo-track is created in the same way as an audio-track
- A tempo-track displays a "tempo-curve" by default
- A tempo-curve visualizes tempo-track's tempo-map
- There may be many tempo-tracks per session
- Soloing a tempo-track exclusively enables only its tempo-map in a session
- Enabled tempo-map defines bars of all tracks
- Saved session stores each tempo-map in the context of its tempo-track
- Enabled tempo-map also get stored globally in the session file (as before)
- Enabled tempo-map can be edited via existing tempo map editor (time-scale double-click)
- Existing tempo-map nodes can be modified via scroll-box (time-track double-click)
- Scroll-box changes of the enabled tempo-track are being displayed and processed on the fly
- Scroll-box changes of the disabled tempo-track only affect its tempo-curve image
- A tempo-track may also be used to record metronome audio-clips (i.e. via metronome input bus)