### PR TITLE
Fix IPlugView leaks for VST3 plugins

### DIFF
--- a/src/qtractorVst3Plugin.cpp
+++ b/src/qtractorVst3Plugin.cpp
@@ -1242,7 +1242,8 @@ bool qtractorVst3PluginType::open (void)
 
 	Vst::IEditController *controller = m_pImpl->controller();
 	if (controller) {
-		IPtr<IPlugView> editor = controller->createView(Vst::ViewType::kEditor);
+		IPtr<IPlugView> editor =
+			Steinberg::owned(controller->createView(Vst::ViewType::kEditor));
 		m_bEditor = (editor != nullptr);
 	}
 
@@ -2348,7 +2349,7 @@ bool qtractorVst3Plugin::Impl::openEditor (void)
 
 	Vst::IEditController *controller = pType->impl()->controller();
 	if (controller)
-		m_plugView = controller->createView(Vst::ViewType::kEditor);
+		m_plugView = Steinberg::owned(controller->createView(Vst::ViewType::kEditor));
 
 	return (m_plugView != nullptr);
 }


### PR DESCRIPTION
Hi,

I noticed that a lot of Windows VST3 plugins running through yabridge were having issues with Qtractor. When I looked into this I noticed that Qtractor creates an `IPlugView` instance during the plugin's initialization, but it then never drops it again and instead it a second `IPlugView` instance while the first one is still alive. I guess some plugins just don't like this.

The issue was that reference counting through `IPtr<IPlugView>` wasn't done correctly, so those objects would always stay at a reference count of at least 1 even when those smart pointers were dropped and the instances would thus never get destroyed. The solution is to use `Steinberg::owned()` whenever a call to a VST3 interface function returns a pointer. That function allows assignment to a smart pointer without increasing the reference count (which will be at 1 by default). I haven't really checked if this same issue also applied elsewhere, but from a quick skim everything else looks correct!