### PR TITLE
Fix lo_* type usage

### DIFF
--- a/src/qtractorDssiPlugin.cpp
+++ b/src/qtractorDssiPlugin.cpp
@@ -440,7 +440,7 @@ static int osc_exiting ( DssiEditor *pDssiEditor )
 
 
 static int osc_message ( const char *path, const char * /*types*/,
-	lo_arg **argv, int /*argc*/, void *data, void * /*user_data*/ )
+	lo_arg **argv, int /*argc*/, lo_message data, void * /*user_data*/ )
 {
 	QMutexLocker locker(&g_oscMutex);
 


### PR DESCRIPTION
Was causing a FTBFS when building against latest liblo using gcc11.