### PR TITLE
Quick hack to get latency compensation when recording.

### DIFF
--- a/src/qtractorSession.cpp
+++ b/src/qtractorSession.cpp
@@ -308,7 +308,7 @@ void qtractorSession::clear (void)
 
 	updateTimeScale();
 
-	qtractorSessionCursor *pAudioCursor = m_pAudioEngine->sessionCursor(); 
+	qtractorSessionCursor *pAudioCursor = m_pAudioEngine->sessionCursor();
 	if (pAudioCursor) {
 		pAudioCursor->resetClips();
 		pAudioCursor->reset();
@@ -316,7 +316,7 @@ void qtractorSession::clear (void)
 		m_cursors.append(pAudioCursor);
 	}
 
-	qtractorSessionCursor *pMidiCursor = m_pMidiEngine->sessionCursor(); 
+	qtractorSessionCursor *pMidiCursor = m_pMidiEngine->sessionCursor();
 	if (pMidiCursor) {
 		pMidiCursor->resetClips();
 		pMidiCursor->reset();
@@ -642,7 +642,7 @@ unsigned long qtractorSession::frameFromPixel ( unsigned int x ) const
 }
 
 unsigned int qtractorSession::pixelFromFrame ( unsigned long iFrame ) const
-{ 
+{
 	return m_props.timeScale.pixelFromFrame(iFrame);
 }
 
@@ -776,7 +776,7 @@ void qtractorSession::updateTimeScaleEx (void)
 
 
 // Update time resolution divisor factors.
-void qtractorSession::updateTimeResolution (void) 
+void qtractorSession::updateTimeResolution (void)
 {
 	// Recompute scale divisor factors...
 	m_props.timeScale.updateScale();
@@ -1136,7 +1136,7 @@ void qtractorSession::resetAllPlugins (void)
 			pTrack; pTrack = pTrack->next()) {
 		(pTrack->pluginList())->resetBuffers();
 	}
-	
+
 	// All audio buses...
 	for (qtractorBus *pBus = m_pAudioEngine->buses().first();
 			pBus; pBus = pBus->next()) {
@@ -1253,7 +1253,7 @@ bool qtractorSession::isPlaying() const
 // Shutdown procedure.
 void qtractorSession::shutdown (void)
 {
-	m_pAudioEngine->setPlaying(false);	
+	m_pAudioEngine->setPlaying(false);
 	m_pMidiEngine->setPlaying(false);
 
 	close();
@@ -1751,7 +1751,13 @@ void qtractorSession::trackRecord (
 		qtractorAudioBus *pAudioBus
 			= static_cast<qtractorAudioBus *> (pTrack->inputBus());
 		if (pAudioBus)
-			pAudioClip->setClipOffset(pAudioBus->latency_in());
+			// This is currently just a workaround, because
+			// we consider here only the output latency of
+			// the current audio bus.
+			// TODO: calculate the overall out latency somehow
+			pAudioClip->setClipOffset(
+						pAudioBus->latency_in()+
+						pAudioBus->latency_out());
 		// One-up audio tracks in record mode.
 		++m_iAudioRecord;
 		break;
@@ -2207,7 +2213,7 @@ bool qtractorSession::loadElement (
 						return false;
 					}
 				}
-				else 
+				else
 				if (eDevice.tagName() == "midi-engine") {
 					if (!qtractorSession::midiEngine()
 							->loadElement(pDocument, &eDevice)) {


### PR DESCRIPTION
When calculating the clip offset, both output and input latency is taken into account.
This works well, if all output busses have the same latency. More work has to be done, if busses with different output latency shell be handled. 