### PR TITLE
CLAP: Implement request_callback

### DIFF
--- a/src/qtractorClapPlugin.cpp
+++ b/src/qtractorClapPlugin.cpp
@@ -32,6 +32,8 @@
 
 #include <clap/clap.h>
 
+#include <QCoreApplication>
+#include <QMetaObject>
 #include <QFileInfo>
 #include <QWidget>
 
@@ -1973,11 +1975,11 @@ void qtractorClapPlugin::Impl::plugin_request_process (void)
 	//
 }
 
-
 void qtractorClapPlugin::Impl::plugin_request_callback (void)
 {
-	// TODO: ?...
-	//
+	QMetaObject::invokeMethod(QCoreApplication::instance(), [this]{
+		m_plugin->on_main_thread(m_plugin);
+	}, Qt::QueuedConnection);
 }
 
 


### PR DESCRIPTION
As discussed in https://www.rncbc.org/drupal/node/2452, Qtractor currently doesn't implement host->request_callback. This provides a pretty straightforward implementation.