### PR TITLE
Proposal Track Auto BackgroundColor

### DIFF
--- a/src/qtractorTrackForm.cpp
+++ b/src/qtractorTrackForm.cpp
@@ -1164,9 +1164,11 @@ void qtractorTrackForm::foregroundColorChanged ( const QString& sText )
 
 	updateColorText(m_ui.ForegroundColorComboBox, m_props.foreground);
 	trackIconChanged();
-	//AutoBackground
+	
+	//AutoBackground Track Color
 	if(m_ui.AutoBackgroundColor->isChecked()){
-	updateColorText(m_ui.BackgroundColorComboBox, m_props.foreground.lighter(200));
+		updateColorText(m_ui.BackgroundColorComboBox, m_props.foreground.lighter(200));
+		m_ui.BackgroundColorComboBox->setCurrentText(m_props.foreground.lighter(200).name());
 	}
 }
 
@@ -1553,10 +1555,12 @@ void qtractorTrackForm::selectForegroundColor (void)
 		m_props.foreground = color;
 		updateColorItem(m_ui.ForegroundColorComboBox, color);
 		trackIconChanged();
-	}
-	//AutoBackground
-	if(m_ui.AutoBackgroundColor->isChecked()){
-	updateColorItem(m_ui.BackgroundColorComboBox, color.lighter(200));
+		
+		//AutoBackground Track Color
+		if(m_ui.AutoBackgroundColor->isChecked()) {
+			updateColorItem(m_ui.BackgroundColorComboBox, color.lighter(200));
+			m_ui.BackgroundColorComboBox->setCurrentText(color.lighter(200).name());
+		}
 	}
 }
 

--- a/src/qtractorTrackForm.cpp
+++ b/src/qtractorTrackForm.cpp
@@ -1164,6 +1164,10 @@ void qtractorTrackForm::foregroundColorChanged ( const QString& sText )
 
 	updateColorText(m_ui.ForegroundColorComboBox, m_props.foreground);
 	trackIconChanged();
+	//AutoBackground
+	if(m_ui.AutoBackgroundColor->isChecked()){
+	updateColorText(m_ui.BackgroundColorComboBox, m_props.foreground.lighter(200));
+	}
 }
 
 
@@ -1549,6 +1553,10 @@ void qtractorTrackForm::selectForegroundColor (void)
 		m_props.foreground = color;
 		updateColorItem(m_ui.ForegroundColorComboBox, color);
 		trackIconChanged();
+	}
+	//AutoBackground
+	if(m_ui.AutoBackgroundColor->isChecked()){
+	updateColorItem(m_ui.BackgroundColorComboBox, color.lighter(200));
 	}
 }
 

--- a/src/qtractorTrackForm.ui
+++ b/src/qtractorTrackForm.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <author>rncbc aka Rui Nuno Capela</author>
  <comment>qtractor - An Audio/MIDI multi-track sequencer.
@@ -25,8 +26,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>380</width>
-    <height>320</height>
+    <width>618</width>
+    <height>570</height>
    </rect>
   </property>
   <property name="focusPolicy">
@@ -36,7 +37,8 @@
    <string>Track</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="qtractor.qrc">:/images/trackProperties.png</iconset>
+   <iconset resource="qtractor.qrc">
+    <normaloff>:/images/trackProperties.png</normaloff>:/images/trackProperties.png</iconset>
   </property>
   <layout class="QVBoxLayout">
    <item>
@@ -109,7 +111,16 @@
          <property name="spacing">
           <number>4</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -121,7 +132,16 @@
             <property name="spacing">
              <number>4</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>8</number>
+            </property>
+            <property name="topMargin">
+             <number>8</number>
+            </property>
+            <property name="rightMargin">
+             <number>8</number>
+            </property>
+            <property name="bottomMargin">
              <number>8</number>
             </property>
             <item>
@@ -156,7 +176,16 @@
             <property name="spacing">
              <number>4</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>8</number>
+            </property>
+            <property name="topMargin">
+             <number>8</number>
+            </property>
+            <property name="rightMargin">
+             <number>8</number>
+            </property>
+            <property name="bottomMargin">
              <number>8</number>
             </property>
             <item>
@@ -233,7 +262,16 @@
           <string>MIDI / Instrument</string>
          </property>
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>8</number>
+          </property>
+          <property name="topMargin">
+           <number>8</number>
+          </property>
+          <property name="rightMargin">
+           <number>8</number>
+          </property>
+          <property name="bottomMargin">
            <number>8</number>
           </property>
           <property name="spacing">
@@ -370,7 +408,16 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>8</number>
+          </property>
+          <property name="topMargin">
+           <number>8</number>
+          </property>
+          <property name="rightMargin">
+           <number>8</number>
+          </property>
+          <property name="bottomMargin">
            <number>8</number>
           </property>
           <item>
@@ -423,7 +470,8 @@
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset resource="qtractor.qrc">:/images/formColor.png</iconset>
+             <iconset resource="qtractor.qrc">
+              <normaloff>:/images/formColor.png</normaloff>:/images/formColor.png</iconset>
             </property>
            </widget>
           </item>
@@ -435,7 +483,7 @@
             <property name="sizeType">
              <enum>QSizePolicy::Expanding</enum>
             </property>
-            <property name="sizeHint">
+            <property name="sizeHint" stdset="0">
              <size>
               <width>8</width>
               <height>8</height>
@@ -449,7 +497,7 @@
              <string>Bac&amp;kground:</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignVCenter</set>
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
             <property name="buddy">
              <cstring>BackgroundColorComboBox</cstring>
@@ -496,7 +544,18 @@
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset resource="qtractor.qrc">:/images/formColor.png</iconset>
+             <iconset resource="qtractor.qrc">
+              <normaloff>:/images/formColor.png</normaloff>:/images/formColor.png</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="AutoBackgroundColor">
+            <property name="text">
+             <string>Auto</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -537,7 +596,8 @@
             <string>&amp;Add...</string>
            </property>
            <property name="icon">
-            <iconset resource="qtractor.qrc">:/images/formCreate.png</iconset>
+            <iconset resource="qtractor.qrc">
+             <normaloff>:/images/formCreate.png</normaloff>:/images/formCreate.png</iconset>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextBesideIcon</enum>
@@ -559,7 +619,8 @@
             <string>&amp;Remove</string>
            </property>
            <property name="icon">
-            <iconset resource="qtractor.qrc">:/images/formRemove.png</iconset>
+            <iconset resource="qtractor.qrc">
+             <normaloff>:/images/formRemove.png</normaloff>:/images/formRemove.png</iconset>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextBesideIcon</enum>
@@ -571,7 +632,7 @@
            <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>
-           <property name="sizeHint">
+           <property name="sizeHint" stdset="0">
             <size>
              <width>8</width>
              <height>8</height>
@@ -594,7 +655,8 @@
             <string>&amp;Up</string>
            </property>
            <property name="icon">
-            <iconset resource="qtractor.qrc">:/images/formMoveUp.png</iconset>
+            <iconset resource="qtractor.qrc">
+             <normaloff>:/images/formMoveUp.png</normaloff>:/images/formMoveUp.png</iconset>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextBesideIcon</enum>
@@ -616,7 +678,8 @@
             <string>&amp;Down</string>
            </property>
            <property name="icon">
-            <iconset resource="qtractor.qrc">:/images/formMoveDown.png</iconset>
+            <iconset resource="qtractor.qrc">
+             <normaloff>:/images/formMoveDown.png</normaloff>:/images/formMoveDown.png</iconset>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextBesideIcon</enum>
@@ -640,7 +703,16 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -651,7 +723,7 @@
            <property name="sizeType">
             <enum>QSizePolicy::Expanding</enum>
            </property>
-           <property name="sizeHint">
+           <property name="sizeHint" stdset="0">
             <size>
              <width>8</width>
              <height>8</height>
@@ -664,11 +736,11 @@
            <property name="toolTip">
             <string>Current total latency</string>
            </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
            <property name="text">
             <string/>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
![prppuesta_auto_color fondo segun principal](https://github.com/rncbc/qtractor/assets/45354881/caaddbe7-afa0-4eb2-9499-c546d8b0e9f6)

90% of the time we want the color of the track and the background of the clip to be the same tone.
It is true that there is a 10% in which it is useful to have the option to differentiate them.

This simple box solves it.

~~The code is fully functional~~, however be careful with the .ui
As you know, Qt Designer does not respect the original code and changes things without me being able to control it.
Also, I'm sure that if you decide to include this feature, you will find a more elegant place to host the check.
I still don't understand the visual tools of Designer.

The proposal is made for your consideration.