### PR TITLE
QSS access for qtractorTrackButton

### DIFF
--- a/src/qtractorMixer.cpp
+++ b/src/qtractorMixer.cpp
@@ -340,22 +340,16 @@ void qtractorMixerStrip::initMixerStrip (void)
 		m_pRecordButton->setFixedHeight(iFixedHeight);
 		m_pRecordButton->setSizePolicy(buttonPolicy);
 		m_pRecordButton->setFont(font3);
-		// QSS access qtractorTrackButton[Type="Record"]
-		m_pRecordButton->setProperty("Type", "Record");
 		m_pMuteButton
 			= new qtractorTrackButton(m_pTrack, qtractorTrack::Mute);
 		m_pMuteButton->setFixedHeight(iFixedHeight);
 		m_pMuteButton->setSizePolicy(buttonPolicy);
 		m_pMuteButton->setFont(font3);
-		// QSS access qtractorTrackButton[Type="Mute"]
-		m_pMuteButton->setProperty("Type", "Mute");
 		m_pSoloButton
 			= new qtractorTrackButton(m_pTrack, qtractorTrack::Solo);
 		m_pSoloButton->setFixedHeight(iFixedHeight);
 		m_pSoloButton->setSizePolicy(buttonPolicy);
 		m_pSoloButton->setFont(font3);
-		// QSS access qtractorTrackButton[Type="Solo"]
-		m_pSoloButton->setProperty("Type", "Solo");
 		m_pButtonLayout->addWidget(m_pRecordButton);
 		m_pButtonLayout->addWidget(m_pMuteButton);
 		m_pButtonLayout->addWidget(m_pSoloButton);
@@ -632,11 +626,15 @@ void qtractorMixerStrip::updateName (void)
 		if (icon.isNull())
 			icon.load(":/images/trackAudio.png");
 		sType = tr("(Audio)");
+		// QSS access qtractorMixerStrip[Type="Audio"]
+		qtractorMixerStrip::setProperty("Type", "Audio");
 		break;
 	case qtractorTrack::Midi:
 		if (icon.isNull())
 			icon.load(":/images/trackMidi.png");
 		sType = tr("(MIDI)");
+		// QSS access qtractorMixerStrip[Type="MIDI"]
+		qtractorMixerStrip::setProperty("Type", "MIDI");
 		break;
 	case qtractorTrack::None:
 	default:

--- a/src/qtractorMixer.cpp
+++ b/src/qtractorMixer.cpp
@@ -1417,10 +1417,15 @@ qtractorMixer::qtractorMixer ( QWidget *pParent, Qt::WindowFlags wflags )
 	QMainWindow::setObjectName("qtractorMixer");
 
 	m_pInputRack  = new qtractorMixerRack(this, tr("Inputs"));
+	// QSS access qtractorMixerRack[Type="Inputs"]
+	m_pInputRack->setProperty("Type", "Inputs");
 	m_pTrackRack  = new qtractorMixerRack(this, tr("Tracks"));
+	// QSS access qtractorMixerRack[Type="Tracks"]
+	m_pTrackRack->setProperty("Type", "Tracks");
 	m_pTrackRack->setSelectEnabled(true);
 	m_pOutputRack = new qtractorMixerRack(this, tr("Outputs"));
-
+	// QSS access qtractorMixerRack[Type="Outputs"]
+	m_pOutputRack->setProperty("Type", "Outputs");
 	// Some specialties to this kind of dock window...
 	QMainWindow::setMinimumWidth(480);
 	QMainWindow::setMinimumHeight(320);

--- a/src/qtractorMixer.cpp
+++ b/src/qtractorMixer.cpp
@@ -340,16 +340,22 @@ void qtractorMixerStrip::initMixerStrip (void)
 		m_pRecordButton->setFixedHeight(iFixedHeight);
 		m_pRecordButton->setSizePolicy(buttonPolicy);
 		m_pRecordButton->setFont(font3);
+		// QSS access qtractorTrackButton[Type="Record"]
+		m_pRecordButton->setProperty("Type", "Record");
 		m_pMuteButton
 			= new qtractorTrackButton(m_pTrack, qtractorTrack::Mute);
 		m_pMuteButton->setFixedHeight(iFixedHeight);
 		m_pMuteButton->setSizePolicy(buttonPolicy);
 		m_pMuteButton->setFont(font3);
+		// QSS access qtractorTrackButton[Type="Mute"]
+		m_pMuteButton->setProperty("Type", "Mute");
 		m_pSoloButton
 			= new qtractorTrackButton(m_pTrack, qtractorTrack::Solo);
 		m_pSoloButton->setFixedHeight(iFixedHeight);
 		m_pSoloButton->setSizePolicy(buttonPolicy);
 		m_pSoloButton->setFont(font3);
+		// QSS access qtractorTrackButton[Type="Solo"]
+		m_pSoloButton->setProperty("Type", "Solo");
 		m_pButtonLayout->addWidget(m_pRecordButton);
 		m_pButtonLayout->addWidget(m_pMuteButton);
 		m_pButtonLayout->addWidget(m_pSoloButton);

--- a/src/qtractorMixer.cpp
+++ b/src/qtractorMixer.cpp
@@ -626,15 +626,15 @@ void qtractorMixerStrip::updateName (void)
 		if (icon.isNull())
 			icon.load(":/images/trackAudio.png");
 		sType = tr("(Audio)");
-		// QSS access qtractorMixerStrip[Type="Audio"]
-		qtractorMixerStrip::setProperty("Type", "Audio");
+		// QSS access qtractorMixerStrip[MixerStripType="Audio"]
+		qtractorMixerStrip::setProperty("MixerStripType", "Audio");
 		break;
 	case qtractorTrack::Midi:
 		if (icon.isNull())
 			icon.load(":/images/trackMidi.png");
 		sType = tr("(MIDI)");
-		// QSS access qtractorMixerStrip[Type="MIDI"]
-		qtractorMixerStrip::setProperty("Type", "MIDI");
+		// QSS access qtractorMixerStrip[MixerStripType="MIDI"]
+		qtractorMixerStrip::setProperty("MixerStripType", "MIDI");
 		break;
 	case qtractorTrack::None:
 	default:
@@ -1415,15 +1415,15 @@ qtractorMixer::qtractorMixer ( QWidget *pParent, Qt::WindowFlags wflags )
 	QMainWindow::setObjectName("qtractorMixer");
 
 	m_pInputRack  = new qtractorMixerRack(this, tr("Inputs"));
-	// QSS access qtractorMixerRack[Type="Inputs"]
-	m_pInputRack->setProperty("Type", "Inputs");
+	// QSS access qtractorMixerRack[MixerRackType="Inputs"]
+	m_pInputRack->setProperty("MixerRackType", "Inputs");
 	m_pTrackRack  = new qtractorMixerRack(this, tr("Tracks"));
-	// QSS access qtractorMixerRack[Type="Tracks"]
-	m_pTrackRack->setProperty("Type", "Tracks");
+	// QSS access qtractorMixerRack[MixerRackType="Tracks"]
+	m_pTrackRack->setProperty("MixerRackType", "Tracks");
 	m_pTrackRack->setSelectEnabled(true);
 	m_pOutputRack = new qtractorMixerRack(this, tr("Outputs"));
-	// QSS access qtractorMixerRack[Type="Outputs"]
-	m_pOutputRack->setProperty("Type", "Outputs");
+	// QSS access qtractorMixerRack[MixerRackType="Outputs"]
+	m_pOutputRack->setProperty("MixerRackType", "Outputs");
 	// Some specialties to this kind of dock window...
 	QMainWindow::setMinimumWidth(480);
 	QMainWindow::setMinimumHeight(320);

--- a/src/qtractorTrackButton.cpp
+++ b/src/qtractorTrackButton.cpp
@@ -84,17 +84,26 @@ qtractorTrackButton::qtractorTrackButton ( qtractorTrack *pTrack,
 	case qtractorTrack::Record:
 		QPushButton::setText("R");
 		QPushButton::setToolTip(tr("Record"));
+		QPushButton::setProperty("Type", "Record");
 		m_rgbOn = Qt::red;
+		// QSS access qtractorTrackButton[Type="Record"]
+		QPushButton::setProperty("Type", "Record");
 		break;
 	case qtractorTrack::Mute:
 		QPushButton::setText("M");
 		QPushButton::setToolTip(tr("Mute"));
+		QPushButton::setProperty("Type", "Mute");
 		m_rgbOn = Qt::yellow;
+		// QSS access qtractorTrackButton[Type="Mute"]
+		QPushButton::setProperty("Type", "Mute");
 		break;
 	case qtractorTrack::Solo:
 		QPushButton::setText("S");
 		QPushButton::setToolTip(tr("Solo"));
+		QPushButton::setProperty("Type", "Solo");
 		m_rgbOn = Qt::cyan;
+		// QSS access qtractorTrackButton[Type="Solo"]
+		QPushButton::setProperty("Type", "Solo");
 		break;
 	}
 

--- a/src/qtractorTrackButton.cpp
+++ b/src/qtractorTrackButton.cpp
@@ -84,26 +84,23 @@ qtractorTrackButton::qtractorTrackButton ( qtractorTrack *pTrack,
 	case qtractorTrack::Record:
 		QPushButton::setText("R");
 		QPushButton::setToolTip(tr("Record"));
-		QPushButton::setProperty("Type", "Record");
+		// QSS access qtractorTrackButton[TrackButtonType="Record"]
+		QPushButton::setProperty("TrackButtonType", "Record");
 		m_rgbOn = Qt::red;
-		// QSS access qtractorTrackButton[Type="Record"]
-		QPushButton::setProperty("Type", "Record");
 		break;
 	case qtractorTrack::Mute:
 		QPushButton::setText("M");
 		QPushButton::setToolTip(tr("Mute"));
-		QPushButton::setProperty("Type", "Mute");
+		// QSS access qtractorTrackButton[TrackButtonType="Mute"]
+		QPushButton::setProperty("TrackButtonType", "Mute");
 		m_rgbOn = Qt::yellow;
-		// QSS access qtractorTrackButton[Type="Mute"]
-		QPushButton::setProperty("Type", "Mute");
 		break;
 	case qtractorTrack::Solo:
 		QPushButton::setText("S");
 		QPushButton::setToolTip(tr("Solo"));
-		QPushButton::setProperty("Type", "Solo");
+		// QSS access qtractorTrackButton[TrackButtonType="Solo"]
+		QPushButton::setProperty("TrackButtonType", "Solo");
 		m_rgbOn = Qt::cyan;
-		// QSS access qtractorTrackButton[Type="Solo"]
-		QPushButton::setProperty("Type", "Solo");
 		break;
 	}
 

--- a/src/qtractorTrackList.cpp
+++ b/src/qtractorTrackList.cpp
@@ -235,14 +235,20 @@ qtractorTrackListButtons::qtractorTrackListButtons (
 	m_pRecordButton = new qtractorTrackButton(pTrack, qtractorTrack::Record, this);
 	m_pRecordButton->setFixedSize(buttonSize);
 	m_pRecordButton->setFont(font2);
+	// QSS access qtractorTrackButton[Type="Record"]
+	m_pRecordButton->setProperty("Type", "Record");
 
 	m_pMuteButton = new qtractorTrackButton(pTrack, qtractorTrack::Mute, this);
 	m_pMuteButton->setFixedSize(buttonSize);
 	m_pMuteButton->setFont(font2);
+	// QSS access qtractorTrackButton[Type="Mute"]
+	m_pMuteButton->setProperty("Type", "Mute");
 
 	m_pSoloButton = new qtractorTrackButton(pTrack, qtractorTrack::Solo, this);
 	m_pSoloButton->setFixedSize(buttonSize);
 	m_pSoloButton->setFont(font2);
+	// QSS access qtractorTrackButton[Type="Solo"]
+	m_pSoloButton->setProperty("Type", "Solo");
 
 	m_pCurveButton = new qtractorCurveButton(pTrack, this);
 	m_pCurveButton->setFixedSize(QSize(32, iFixedHeight));

--- a/src/qtractorTrackList.cpp
+++ b/src/qtractorTrackList.cpp
@@ -235,20 +235,14 @@ qtractorTrackListButtons::qtractorTrackListButtons (
 	m_pRecordButton = new qtractorTrackButton(pTrack, qtractorTrack::Record, this);
 	m_pRecordButton->setFixedSize(buttonSize);
 	m_pRecordButton->setFont(font2);
-	// QSS access qtractorTrackButton[Type="Record"]
-	m_pRecordButton->setProperty("Type", "Record");
 
 	m_pMuteButton = new qtractorTrackButton(pTrack, qtractorTrack::Mute, this);
 	m_pMuteButton->setFixedSize(buttonSize);
 	m_pMuteButton->setFont(font2);
-	// QSS access qtractorTrackButton[Type="Mute"]
-	m_pMuteButton->setProperty("Type", "Mute");
 
 	m_pSoloButton = new qtractorTrackButton(pTrack, qtractorTrack::Solo, this);
 	m_pSoloButton->setFixedSize(buttonSize);
 	m_pSoloButton->setFont(font2);
-	// QSS access qtractorTrackButton[Type="Solo"]
-	m_pSoloButton->setProperty("Type", "Solo");
 
 	m_pCurveButton = new qtractorCurveButton(pTrack, this);
 	m_pCurveButton->setFixedSize(QSize(32, iFixedHeight));


### PR DESCRIPTION
Estimated Rui:

Is it necessary to make Qtractor more accessible through QSS?
I believe this would simplify the development of new features.
Many of them without having to touch code or compile.
It would simplify the internal code, you would only have to designate one property, the one that gives access through QSS.
The rest, sizes, color... would be applied externally.
I would separate the logic from the visual part.

But of course I could be wrong.

I suppose that performance and stability issues also come into play, which could be of concern in this approach.


My initial starting intention was:

qtractorMixerRackWidget & qtractorMixerRackTitleBarWidget
   type= BusIn, Track, BusOut

qtractorMixerStrip
   type=Midi, Audio
   selected=true, false

qtractorTrackButton
   type= Record, Mute, Solo

Of these I have only gotten "qtractorTrackButton". The rest do not apply the properties directly to the widget, and my limited knowledge has not allowed me to solve it.

I have come to the conclusion that with my proposals I hinder rather than help.
If I don't have the knowledge, it's better to just enjoy what you've already given us.

Sorry for the inconvenience caused, from now on I will dedicate myself to enjoying Qtractor :)
Thanks for everything.