### PR TITLE
Fix misaligned LV2 Atoms

### DIFF
--- a/src/lv2/lv2_atom_helpers.h
+++ b/src/lv2/lv2_atom_helpers.h
@@ -55,6 +55,7 @@ struct _LV2_Atom_Buffer
 	uint32_t capacity;
 	uint32_t chunk_type;
 	uint32_t sequence_type;
+	uint32_t _alignment_padding;
 	LV2_Atom_Sequence aseq;
 
 } LV2_Atom_Buffer;


### PR DESCRIPTION
ubsan detects misaligned reads/writes on lv2 atom ports.

This adds _alignment_padding to _LV2_Atom_Buffer.

from,

https://lv2plug.in/ns/ext/atom

"An LV2_Atom has a 32-bit size and type, followed by a body of size bytes. Atoms MUST be 64-bit aligned."