### PR TITLE
Feature: Add the ability to lock toolbars in place

### DIFF
--- a/src/qtractorMainForm.cpp
+++ b/src/qtractorMainForm.cpp
@@ -1084,6 +1084,9 @@ qtractorMainForm::qtractorMainForm (
 	QObject::connect(m_ui.viewToolbarThumbAction,
 		SIGNAL(triggered(bool)),
 		SLOT(viewToolbarThumb(bool)));
+	QObject::connect(m_ui.viewToolbarLockedAction,
+		SIGNAL(triggered(bool)),
+		SLOT(viewToolbarLocked(bool)));
 	QObject::connect(m_ui.viewFileSystemAction,
 		SIGNAL(triggered(bool)),
 		SLOT(viewFileSystem(bool)));
@@ -1461,6 +1464,7 @@ void qtractorMainForm::setup ( qtractorOptions *pOptions )
 	m_ui.viewToolbarTransportAction->setChecked(m_pOptions->bTransportToolbar);
 	m_ui.viewToolbarTimeAction->setChecked(m_pOptions->bTimeToolbar);
 	m_ui.viewToolbarThumbAction->setChecked(m_pOptions->bThumbToolbar);
+	m_ui.viewToolbarLockedAction->setChecked(m_pOptions->bLockedToolbar);
 	m_ui.viewSnapZebraAction->setChecked(pOptions->bTrackViewSnapZebra);
 	m_ui.viewSnapGridAction->setChecked(pOptions->bTrackViewSnapGrid);
 	m_ui.viewToolTipsAction->setChecked(pOptions->bTrackViewToolTips);
@@ -1485,6 +1489,7 @@ void qtractorMainForm::setup ( qtractorOptions *pOptions )
 	viewToolbarTransport(m_pOptions->bTransportToolbar);
 	viewToolbarTime(m_pOptions->bTimeToolbar);
 	viewToolbarThumb(m_pOptions->bThumbToolbar);
+	viewToolbarLocked(m_pOptions->bLockedToolbar);
 
 	// Restore whole dock windows state.
 	const QByteArray aDockables
@@ -1822,6 +1827,7 @@ bool qtractorMainForm::queryClose (void)
 				m_pOptions->bTransportToolbar = m_ui.transportToolbar->isVisible();
 				m_pOptions->bTimeToolbar = m_ui.timeToolbar->isVisible();
 				m_pOptions->bThumbToolbar = m_ui.thumbViewToolbar->isVisible();
+				m_pOptions->bLockedToolbar = m_ui.viewToolbarLockedAction->isChecked();
 			}
 			m_pOptions->bTrackViewSnapZebra = m_ui.viewSnapZebraAction->isChecked();
 			m_pOptions->bTrackViewSnapGrid = m_ui.viewSnapGridAction->isChecked();
@@ -5210,6 +5216,20 @@ void qtractorMainForm::viewToolbarTime ( bool bOn )
 void qtractorMainForm::viewToolbarThumb ( bool bOn )
 {
 	m_ui.thumbViewToolbar->setVisible(bOn);
+}
+
+
+// Lock/unlock main program window toolbar positions.
+void qtractorMainForm::viewToolbarLocked ( bool bOn )
+{
+	m_ui.fileToolbar->setMovable(!bOn);
+	m_ui.editToolbar->setMovable(!bOn);
+	m_ui.trackToolbar->setMovable(!bOn);
+	m_ui.viewToolbar->setMovable(!bOn);
+	m_ui.optionsToolbar->setMovable(!bOn);
+	m_ui.transportToolbar->setMovable(!bOn);
+	m_ui.timeToolbar->setMovable(!bOn);
+	m_ui.thumbViewToolbar->setMovable(!bOn);
 }
 
 

--- a/src/qtractorMainForm.h
+++ b/src/qtractorMainForm.h
@@ -253,6 +253,7 @@ public slots:
 	void viewToolbarTransport(bool bOn);
 	void viewToolbarTime(bool bOn);
 	void viewToolbarThumb(bool bOn);
+	void viewToolbarLocked(bool bOn);
 	void viewFileSystem(bool bOn);
 	void viewFiles(bool bOn);
 	void viewMessages(bool bOn);

--- a/src/qtractorMainForm.ui
+++ b/src/qtractorMainForm.ui
@@ -464,6 +464,8 @@
      <addaction name="viewToolbarTransportAction"/>
      <addaction name="viewToolbarTimeAction"/>
      <addaction name="viewToolbarThumbAction"/>
+     <addaction name="separator"/>
+     <addaction name="viewToolbarLockedAction"/>
     </widget>
     <widget class="QMenu" name="viewWindowsMenu">
      <property name="title">
@@ -2317,6 +2319,23 @@
    <property name="statusTip">
     <string>Show/hide main program window thumb toolbar</string>
    </property>
+  </action>
+  <action name="viewToolbarLockedAction">
+    <property name="checkable">
+      <bool>true</bool>
+    </property>
+    <property name="text">
+      <string>Loc&amp;k Toolbars</string>
+    </property>
+    <property name="iconText">
+      <string>Lock Toolbar Positions</string>
+    </property>
+    <property name="toolTip">
+      <string>Lock Toolbar Positions</string>
+    </property>
+    <property name="statusTip">
+      <string>Lock/unlock main program window toolbar positions</string>
+    </property>
   </action>
   <action name="viewFileSystemAction">
    <property name="checkable">

--- a/src/qtractorMidiEditorForm.cpp
+++ b/src/qtractorMidiEditorForm.cpp
@@ -551,6 +551,9 @@ qtractorMidiEditorForm::qtractorMidiEditorForm (
 	QObject::connect(m_ui.viewToolbarThumbAction,
 		SIGNAL(triggered(bool)),
 		SLOT(viewToolbarThumb(bool)));
+	QObject::connect(m_ui.viewToolbarLockedAction,
+		SIGNAL(triggered(bool)),
+		SLOT(viewToolbarLocked(bool)));
 	QObject::connect(m_ui.viewEventsAction,
 		SIGNAL(triggered(bool)),
 		SLOT(viewEvents(bool)));
@@ -707,6 +710,7 @@ qtractorMidiEditorForm::qtractorMidiEditorForm (
 		m_ui.viewToolbarTimeAction->setChecked(pOptions->bMidiTimeToolbar);
 		m_ui.viewToolbarScaleAction->setChecked(pOptions->bMidiScaleToolbar);
 		m_ui.viewToolbarThumbAction->setChecked(pOptions->bMidiThumbToolbar);
+		m_ui.viewToolbarLockedAction->setChecked(pOptions->bMidiLockedToolbar);
 		m_ui.viewNoteNamesAction->setChecked(pOptions->bMidiNoteNames);
 		m_ui.viewNoteDurationAction->setChecked(pOptions->bMidiNoteDuration);
 		m_ui.viewNoteColorAction->setChecked(pOptions->bMidiNoteColor);
@@ -736,6 +740,7 @@ qtractorMidiEditorForm::qtractorMidiEditorForm (
 		viewToolbarTime(pOptions->bMidiTimeToolbar);
 		viewToolbarScale(pOptions->bMidiScaleToolbar);
 		viewToolbarThumb(pOptions->bMidiThumbToolbar);
+		viewToolbarLocked(pOptions->bMidiLockedToolbar);
 		m_pMidiEditor->setZoomMode(pOptions->iMidiZoomMode);
 		m_pMidiEditor->setHorizontalZoom(pOptions->iMidiHorizontalZoom);
 		m_pMidiEditor->setVerticalZoom(pOptions->iMidiVerticalZoom);
@@ -955,6 +960,7 @@ void qtractorMidiEditorForm::closeEvent ( QCloseEvent *pCloseEvent )
 		pOptions->bMidiTransportToolbar = m_ui.transportToolbar->isVisible();
 		pOptions->bMidiTimeToolbar = m_ui.timeToolbar->isVisible();
 		pOptions->bMidiScaleToolbar = m_ui.snapToScaleToolbar->isVisible();
+		pOptions->bMidiLockedToolbar = m_ui.viewToolbarLockedAction->isChecked();
 		pOptions->iMidiZoomMode = m_pMidiEditor->zoomMode();
 		pOptions->iMidiHorizontalZoom = m_pMidiEditor->horizontalZoom();
 		pOptions->iMidiVerticalZoom = m_pMidiEditor->verticalZoom();
@@ -1821,6 +1827,21 @@ void qtractorMidiEditorForm::viewToolbarScale ( bool bOn )
 void qtractorMidiEditorForm::viewToolbarThumb ( bool bOn )
 {
 	m_ui.thumbViewToolbar->setVisible(bOn);
+}
+
+
+// Lock/unlock midi window toolbar positions.
+void qtractorMidiEditorForm::viewToolbarLocked ( bool bOn )
+{
+	m_ui.fileToolbar->setMovable(!bOn);
+	m_ui.editToolbar->setMovable(!bOn);
+	m_ui.viewToolbar->setMovable(!bOn);
+	m_ui.transportToolbar->setMovable(!bOn);
+	m_ui.timeToolbar->setMovable(!bOn);
+	m_ui.snapToScaleToolbar->setMovable(!bOn);
+	m_ui.thumbViewToolbar->setMovable(!bOn);
+	m_ui.editEventToolbar->setMovable(!bOn);
+	m_ui.editViewToolbar->setMovable(!bOn);
 }
 
 

--- a/src/qtractorMidiEditorForm.h
+++ b/src/qtractorMidiEditorForm.h
@@ -160,6 +160,7 @@ protected slots:
 	void viewToolbarTime(bool bOn);
 	void viewToolbarScale(bool bOn);
 	void viewToolbarThumb(bool bOn);
+	void viewToolbarLocked(bool bOn);
 	void viewEvents(bool bOn);
 	void viewNoteNames(bool bOn);
 	void viewNoteDuration(bool bOn);

--- a/src/qtractorMidiEditorForm.ui
+++ b/src/qtractorMidiEditorForm.ui
@@ -96,6 +96,8 @@
      <addaction name="viewToolbarTimeAction"/>
      <addaction name="viewToolbarScaleAction"/>
      <addaction name="viewToolbarThumbAction"/>
+     <addaction name="separator"/>
+     <addaction name="viewToolbarLockedAction"/>
     </widget>
     <widget class="QMenu" name="viewWindowsMenu">
      <property name="title">
@@ -1206,6 +1208,23 @@
    <property name="statusTip">
     <string>Show/hide the thumb view toolbar</string>
    </property>
+  </action>
+  <action name="viewToolbarLockedAction">
+    <property name="checkable">
+      <bool>true</bool>
+    </property>
+    <property name="text">
+      <string>Loc&amp;k Toolbars</string>
+    </property>
+    <property name="iconText">
+      <string>Lock Toolbar Positions</string>
+    </property>
+    <property name="toolTip">
+      <string>Lock Toolbar Positions</string>
+    </property>
+    <property name="statusTip">
+      <string>Lock/unlock midi window toolbar positions</string>
+    </property>
   </action>
   <action name="viewEventsAction">
    <property name="checkable">

--- a/src/qtractorOptions.cpp
+++ b/src/qtractorOptions.cpp
@@ -130,6 +130,7 @@ void qtractorOptions::loadOptions (void)
 	bTransportToolbar = m_settings.value("/TransportToolbar", true).toBool();
 	bTimeToolbar    = m_settings.value("/TimeToolbar", true).toBool();
 	bThumbToolbar   = m_settings.value("/ThumbToolbar", true).toBool();
+	bLockedToolbar    = m_settings.value("/LockedToolbar", true).toBool();
 	iZoomMode       = m_settings.value("/ZoomMode", 1).toInt();
 	m_settings.endGroup();
 
@@ -370,6 +371,7 @@ void qtractorOptions::loadOptions (void)
 	bMidiScaleToolbar = m_settings.value("/ScaleToolbar", false).toBool();
 	bMidiTimeToolbar = m_settings.value("/TimeToolbar", false).toBool();
 	bMidiThumbToolbar = m_settings.value("/ThumbToolbar", true).toBool();
+	bMidiLockedToolbar    = m_settings.value("/LockedToolbar", true).toBool();
 	iMidiDisplayFormat = m_settings.value("/DisplayFormat", 2).toInt();
 	bMidiNoteNames   = m_settings.value("/NoteNames", false).toBool();
 	bMidiNoteDuration = m_settings.value("/NoteDuration", true).toBool();
@@ -479,6 +481,7 @@ void qtractorOptions::saveOptions (void)
 	m_settings.setValue("/TransportToolbar", bTransportToolbar);
 	m_settings.setValue("/TimeToolbar", bTimeToolbar);
 	m_settings.setValue("/ThumbToolbar", bThumbToolbar);
+	m_settings.setValue("/LockedToolbar", bLockedToolbar);
 	m_settings.setValue("/ZoomMode", iZoomMode);
 	m_settings.endGroup();
 
@@ -691,6 +694,7 @@ void qtractorOptions::saveOptions (void)
 	m_settings.setValue("/TimeToolbar", bMidiTimeToolbar);
 	m_settings.setValue("/ScaleToolbar", bMidiScaleToolbar);
 	m_settings.setValue("/ThumbToolbar", bMidiThumbToolbar);
+	m_settings.setValue("/LockedToolbar", bMidiLockedToolbar);
 	m_settings.setValue("/DisplayFormat", iMidiDisplayFormat);
 	m_settings.setValue("/NoteNames", bMidiNoteNames);
 	m_settings.setValue("/NoteDuration", bMidiNoteDuration);

--- a/src/qtractorOptions.h
+++ b/src/qtractorOptions.h
@@ -95,6 +95,7 @@ public:
 	bool    bTransportToolbar;
 	bool    bTimeToolbar;
 	bool    bThumbToolbar;
+	bool    bLockedToolbar;
 	int     iZoomMode;
 
 	// Transport options...
@@ -310,6 +311,7 @@ public:
 	bool bMidiTimeToolbar;
 	bool bMidiScaleToolbar;
 	bool bMidiThumbToolbar;
+	bool bMidiLockedToolbar;
 	int  iMidiDisplayFormat;
 	bool bMidiNoteNames;
 	bool bMidiNoteDuration;


### PR DESCRIPTION
## Feature Description
Most QT Widgets applications offer an option to lock/unlock the movable toolbars e.g. Dolphin, Kate, etc... This provides both more space on the toolbars and prevents them from being accidentally moved.

Example with Kate:
<img width="378" height="223" alt="image" src="https://github.com/user-attachments/assets/d7552ad5-7a6c-4844-bb4f-e83228bfc323" /> <img width="384" height="245" alt="image" src="https://github.com/user-attachments/assets/d6ea2471-cc9f-4d70-ad61-f4d2fc7bab83" />

## Implementation 
These applications usually hide this functionality behind a right click window, however this would not mesh well with QTractor's current design. Instead this PR adds the option in the menubar under View->Toolbars. This functionality was added to both the main window and the MIDI window, which work independently from each other.

For the Main Window:

<img width="1600" height="427" alt="image" src="https://github.com/user-attachments/assets/771cad64-260f-45af-9e72-8989579ef0b6" />
<img width="1661" height="418" alt="image" src="https://github.com/user-attachments/assets/bcfe9133-1f85-430b-8ac8-591cbd625978" />


For the MIDI window:

<img width="1203" height="584" alt="image" src="https://github.com/user-attachments/assets/9b1724be-7caf-49f1-bf03-bea3d99a29d4" />
<img width="1281" height="575" alt="image" src="https://github.com/user-attachments/assets/0c5bcad5-f523-456f-907d-aa3ef7bed9ee" />

